### PR TITLE
(See PR#14 instead) Update `zcash_note_encryption` to support variable note plaintext and encrypted note ciphertext sizes

### DIFF
--- a/components/zcash_note_encryption/src/batch.rs
+++ b/components/zcash_note_encryption/src/batch.rs
@@ -3,8 +3,10 @@
 use alloc::vec::Vec; // module is alloc only
 
 use crate::{
-    try_compact_note_decryption_inner, try_note_decryption_inner, BatchDomain, EphemeralKeyBytes,
-    ShieldedOutput, COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE,
+    try_compact_note_decryption_inner, try_note_decryption_inner,
+    BatchDomain, EphemeralKeyBytes,
+    ShieldedOutput,
+    // COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE,
 };
 
 /// Trial decryption of a batch of notes with a set of recipients.
@@ -16,7 +18,7 @@ use crate::{
 /// provided, along with the index in the `ivks` slice associated with
 /// the IVK that successfully decrypted the output.
 #[allow(clippy::type_complexity)]
-pub fn try_note_decryption<D: BatchDomain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>>(
+pub fn try_note_decryption<D: BatchDomain, Output: ShieldedOutput<D>>(
     ivks: &[D::IncomingViewingKey],
     outputs: &[(D, Output)],
 ) -> Vec<Option<((D::Note, D::Recipient, D::Memo), usize)>> {
@@ -32,14 +34,14 @@ pub fn try_note_decryption<D: BatchDomain, Output: ShieldedOutput<D, ENC_CIPHERT
 /// provided, along with the index in the `ivks` slice associated with
 /// the IVK that successfully decrypted the output.
 #[allow(clippy::type_complexity)]
-pub fn try_compact_note_decryption<D: BatchDomain, Output: ShieldedOutput<D, COMPACT_NOTE_SIZE>>(
+pub fn try_compact_note_decryption<D: BatchDomain, Output: ShieldedOutput<D>>(
     ivks: &[D::IncomingViewingKey],
     outputs: &[(D, Output)],
 ) -> Vec<Option<((D::Note, D::Recipient), usize)>> {
     batch_note_decryption(ivks, outputs, try_compact_note_decryption_inner)
 }
 
-fn batch_note_decryption<D: BatchDomain, Output: ShieldedOutput<D, CS>, F, FR, const CS: usize>(
+fn batch_note_decryption<D: BatchDomain, Output: ShieldedOutput<D>, F, FR>(
     ivks: &[D::IncomingViewingKey],
     outputs: &[(D, Output)],
     decrypt_inner: F,

--- a/components/zcash_note_encryption/src/batch.rs
+++ b/components/zcash_note_encryption/src/batch.rs
@@ -6,7 +6,6 @@ use crate::{
     try_compact_note_decryption_inner, try_note_decryption_inner,
     BatchDomain, EphemeralKeyBytes,
     ShieldedOutput,
-    // COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE,
 };
 
 /// Trial decryption of a batch of notes with a set of recipients.

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -24,12 +24,19 @@ extern crate alloc;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-use chacha20::{
-    cipher::{StreamCipher, StreamCipherSeek},
-    ChaCha20,
+// use core::convert::TryInto;
+
+// use chacha20::{
+//     cipher::{StreamCipher, StreamCipherSeek},
+//     ChaCha20,
+// };
+use chacha20poly1305::{
+    aead::AeadInPlace,
+    ChaCha20Poly1305,
+    KeyInit,
 };
-use chacha20poly1305::{aead::AeadInPlace, ChaCha20Poly1305, KeyInit};
-use cipher::KeyIvInit;
+
+// use cipher::KeyIvInit;
 
 use rand_core::RngCore;
 use subtle::{Choice, ConstantTimeEq};
@@ -93,8 +100,6 @@ impl ConstantTimeEq for EphemeralKeyBytes {
     }
 }
 
-/// Newtype representing the byte encoding of a note plaintext.
-pub struct NotePlaintextBytes(pub [u8; NOTE_PLAINTEXT_SIZE]);
 /// Newtype representing the byte encoding of a outgoing plaintext.
 pub struct OutPlaintextBytes(pub [u8; OUT_PLAINTEXT_SIZE]);
 
@@ -102,6 +107,58 @@ pub struct OutPlaintextBytes(pub [u8; OUT_PLAINTEXT_SIZE]);
 enum NoteValidity {
     Valid,
     Invalid,
+}
+
+// /// Enum for the note plaintext.
+// /// The variants represent whether the note is a full note or a compact note.
+// #[derive(Copy, Clone, PartialEq, Eq)]
+// enum NotePlaintext<D: Domain> {
+//     Full(D::NotePlaintextBytes),
+//     Compact(D::CompactNotePlaintextBytes),
+// }
+
+/// Enum for the note ciphertext.
+/// The variants represent whether the encrypted note is a full note or a compact note.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum NoteCiphertext<D: Domain> {
+    Full(D::EncNoteCiphertextBytes),
+    Compact(D::CompactEncNoteCiphertextBytes),
+}
+
+// /// Function to extract the full note plaintext from the `NotePlaintext` enum.
+// /// Returns `None` if the enum variant is `Compact`.
+// pub fn extract_full_note_plaintext<D: Domain>(np: NotePlaintext<D>) -> Option<D::NotePlaintextBytes> {
+//     match np {
+//         NotePlaintext::Full(x) => Some(x),
+//         NotePlaintext::Compact(_) => None,
+//     }
+// }
+
+// /// Function to extract the compact note plaintext from the `NotePlaintext` enum.
+// /// Returns `None` if the enum variant is `Full`.
+// pub fn extract_compact_note_plaintext<D: Domain>(np: NotePlaintext<D>) -> Option<D::CompactNotePlaintextBytes> {
+//     match np {
+//         NotePlaintext::Full(_) => None,
+//         NotePlaintext::Compact(x) => Some(x),
+//     }
+// }
+
+/// Function to extract the full encrypted note ciphertext from the `NoteCiphertext` enum.
+/// Returns `None` if the enum variant is `Compact`.
+pub fn extract_full_note_ciphertext<D: Domain>(nc: NoteCiphertext<D>) -> Option<D::EncNoteCiphertextBytes> {
+    match nc {
+        NoteCiphertext::Full(x) => Some(x),
+        NoteCiphertext::Compact(_) => None,
+    }
+}
+
+/// Function to extract the compact encrypted note ciphertext from the `NoteCiphertext` enum.
+/// Returns `None` if the enum variant is `Full`.
+pub fn extract_compact_note_ciphertext<D: Domain>(nc: NoteCiphertext<D>) -> Option<D::CompactEncNoteCiphertextBytes> {
+    match nc {
+        NoteCiphertext::Full(_) => None,
+        NoteCiphertext::Compact(x) => Some(x),
+    }
 }
 
 /// Trait that encapsulates protocol-specific note encryption types and logic.
@@ -115,6 +172,10 @@ pub trait Domain {
     type SharedSecret;
     type SymmetricKey: AsRef<[u8]>;
     type Note;
+    type NotePlaintextBytes;
+    type EncNoteCiphertextBytes;
+    type CompactNotePlaintextBytes;
+    type CompactEncNoteCiphertextBytes;
     type Recipient;
     type DiversifiedTransmissionKey;
     type IncomingViewingKey;
@@ -184,7 +245,7 @@ pub trait Domain {
         note: &Self::Note,
         recipient: &Self::Recipient,
         memo: &Self::Memo,
-    ) -> NotePlaintextBytes;
+    ) -> Self::NotePlaintextBytes;
 
     /// Derives the [`OutgoingCipherKey`] for an encrypted note, given the note-specific
     /// public data and an `OutgoingViewingKey`.
@@ -226,13 +287,12 @@ pub trait Domain {
     ///
     /// [ZIP 212]: https://zips.z.cash/zip-0212
     ///
-    /// # Panics
-    ///
-    /// Panics if `plaintext` is shorter than [`COMPACT_NOTE_SIZE`].
+    /// This function only takes in plaintext bytes with the memo removed, as in compact notes.
+    /// If working with full notes, first convert to compact note using `convert_to_compact_plaintext`.
     fn parse_note_plaintext_without_memo_ivk(
         &self,
         ivk: &Self::IncomingViewingKey,
-        plaintext: &[u8],
+        plaintext: &Self::CompactNotePlaintextBytes,
     ) -> Option<(Self::Note, Self::Recipient)>;
 
     /// Parses the given note plaintext from the sender's perspective.
@@ -249,12 +309,15 @@ pub trait Domain {
     /// such as rules like [ZIP 212] that become active at a specific block height.
     ///
     /// [ZIP 212]: https://zips.z.cash/zip-0212
+    ///
+    /// This function only takes in plaintext bytes with the memo removed, as in compact notes.
+    /// If working with full notes, first convert to compact note using `convert_to_compact_plaintext`.
     fn parse_note_plaintext_without_memo_ovk(
         &self,
         pk_d: &Self::DiversifiedTransmissionKey,
         esk: &Self::EphemeralSecretKey,
         ephemeral_key: &EphemeralKeyBytes,
-        plaintext: &NotePlaintextBytes,
+        plaintext: &Self::CompactNotePlaintextBytes,
     ) -> Option<(Self::Note, Self::Recipient)>;
 
     /// Extracts the memo field from the given note plaintext.
@@ -263,7 +326,7 @@ pub trait Domain {
     ///
     /// `&self` is passed here in anticipation of future changes to memo handling, where
     /// the memos may no longer be part of the note plaintext.
-    fn extract_memo(&self, plaintext: &NotePlaintextBytes) -> Self::Memo;
+    fn extract_memo(&self, plaintext: &Self::NotePlaintextBytes) -> Self::Memo;
 
     /// Parses the `DiversifiedTransmissionKey` field of the outgoing plaintext.
     ///
@@ -276,6 +339,35 @@ pub trait Domain {
     /// Returns `None` if `out_plaintext` does not contain a valid byte encoding of an
     /// `EphemeralSecretKey`.
     fn extract_esk(out_plaintext: &OutPlaintextBytes) -> Option<Self::EphemeralSecretKey>;
+
+    /// Returns a vector with the bytes of the note plaintext.
+    fn vec_note_plaintext(plaintext: &Self::NotePlaintextBytes) -> Vec<u8>;
+
+    /// Returns a vector with the bytes of the encrypted note ciphertext.
+    fn vec_enc_note_ciphertext(enc_note_ciphertext: &Self::EncNoteCiphertextBytes) -> Vec<u8>;
+
+    /// Performs the inner encryption logic given the key and the note plaintext, and returns
+    /// the encrypted note ciphertext.
+    fn encrypt_with_key(
+        key: Self::SymmetricKey,
+        input: Self::NotePlaintextBytes,
+    ) -> Self::EncNoteCiphertextBytes;
+
+    /// Performs the inner decryption logic given the key and the encrypted note ciphertext,
+    /// and returns the note plaintext.
+    fn decrypt_with_key(
+        key: &Self::SymmetricKey,
+        enc_ciphertext: Self::EncNoteCiphertextBytes,
+    ) -> Self::NotePlaintextBytes;
+
+    /// Performs the inner decryption logic for compct notes given the key and the
+    /// compact encrypted note ciphertext, and returns the compact note plaintext.
+    fn decrypt_compact_with_key(
+        key: &Self::SymmetricKey,
+        enc_ciphertext: Self::CompactEncNoteCiphertextBytes,
+    ) -> Self::CompactNotePlaintextBytes;
+
+    fn convert_to_compact_plaintext(full_note: &Self::NotePlaintextBytes) -> Self::CompactNotePlaintextBytes;
 }
 
 /// Trait that encapsulates protocol-specific batch trial decryption logic.
@@ -322,11 +414,7 @@ pub trait BatchDomain: Domain {
 }
 
 /// Trait that provides access to the components of an encrypted transaction output.
-///
-/// Implementations of this trait are required to define the length of their ciphertext
-/// field. In order to use the trial decryption APIs in this crate, the length must be
-/// either [`ENC_CIPHERTEXT_SIZE`] or [`COMPACT_NOTE_SIZE`].
-pub trait ShieldedOutput<D: Domain, const CIPHERTEXT_SIZE: usize> {
+pub trait ShieldedOutput<D: Domain> {
     /// Exposes the `ephemeral_key` field of the output.
     fn ephemeral_key(&self) -> EphemeralKeyBytes;
 
@@ -334,7 +422,7 @@ pub trait ShieldedOutput<D: Domain, const CIPHERTEXT_SIZE: usize> {
     fn cmstar_bytes(&self) -> D::ExtractedCommitmentBytes;
 
     /// Exposes the note ciphertext of the output.
-    fn enc_ciphertext(&self) -> &[u8; CIPHERTEXT_SIZE];
+    fn enc_ciphertext(&self) -> NoteCiphertext<D>;
 }
 
 /// A struct containing context required for encrypting Sapling and Orchard notes.
@@ -408,24 +496,25 @@ impl<D: Domain> NoteEncryption<D> {
     }
 
     /// Generates `encCiphertext` for this note.
-    pub fn encrypt_note_plaintext(&self) -> [u8; ENC_CIPHERTEXT_SIZE] {
+    pub fn encrypt_note_plaintext(&self) -> D::EncNoteCiphertextBytes {
         let pk_d = D::get_pk_d(&self.note);
         let shared_secret = D::ka_agree_enc(&self.esk, &pk_d);
         let key = D::kdf(shared_secret, &D::epk_bytes(&self.epk));
         let input = D::note_plaintext_bytes(&self.note, &self.to, &self.memo);
 
-        let mut output = [0u8; ENC_CIPHERTEXT_SIZE];
-        output[..NOTE_PLAINTEXT_SIZE].copy_from_slice(&input.0);
-        let tag = ChaCha20Poly1305::new(key.as_ref().into())
-            .encrypt_in_place_detached(
-                [0u8; 12][..].into(),
-                &[],
-                &mut output[..NOTE_PLAINTEXT_SIZE],
-            )
-            .unwrap();
-        output[NOTE_PLAINTEXT_SIZE..].copy_from_slice(&tag);
-
-        output
+        D::encrypt_with_key(key, input)
+        // let mut output = [0u8; ENC_CIPHERTEXT_SIZE];
+        // output[..NOTE_PLAINTEXT_SIZE].copy_from_slice(&input.0);
+        // let tag = ChaCha20Poly1305::new(key.as_ref().into())
+        //     .encrypt_in_place_detached(
+        //         [0u8; 12][..].into(),
+        //         &[],
+        //         &mut output[..NOTE_PLAINTEXT_SIZE],
+        //     )
+        //     .unwrap();
+        // output[NOTE_PLAINTEXT_SIZE..].copy_from_slice(&tag);
+        //
+        // output
     }
 
     /// Generates `outCiphertext` for this note.
@@ -470,7 +559,12 @@ impl<D: Domain> NoteEncryption<D> {
 ///
 /// Implements section 4.19.2 of the
 /// [Zcash Protocol Specification](https://zips.z.cash/protocol/nu5.pdf#decryptivk).
-pub fn try_note_decryption<D: Domain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>>(
+///
+/// This function is only meant to be used with full notes, not compact notes.
+/// If the note is a compact note, then this function returns `None`.
+///
+/// For compact notes, use 'try_compact_note_decryption` and `try_compact_note_decryption_inner`.
+pub fn try_note_decryption<D: Domain, Output: ShieldedOutput<D>>(
     domain: &D,
     ivk: &D::IncomingViewingKey,
     output: &Output,
@@ -484,45 +578,59 @@ pub fn try_note_decryption<D: Domain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_S
     try_note_decryption_inner(domain, ivk, &ephemeral_key, output, &key)
 }
 
-fn try_note_decryption_inner<D: Domain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>>(
+/// This function is only meant to be used with full notes, not compact notes.
+/// If the note is a compact note, then this function returns `None`.
+///
+/// For compact notes, use 'try_compact_note_decryption` and `try_compact_note_decryption_inner`.
+fn try_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
     domain: &D,
     ivk: &D::IncomingViewingKey,
     ephemeral_key: &EphemeralKeyBytes,
     output: &Output,
     key: &D::SymmetricKey,
 ) -> Option<(D::Note, D::Recipient, D::Memo)> {
-    let enc_ciphertext = output.enc_ciphertext();
 
-    let mut plaintext =
-        NotePlaintextBytes(enc_ciphertext[..NOTE_PLAINTEXT_SIZE].try_into().unwrap());
+    let enc_ciphertext: D::EncNoteCiphertextBytes;
+    if let Some(x) = extract_full_note_ciphertext(output.enc_ciphertext()) {
+        enc_ciphertext = x;
+    } else {
+        return None;
+    }
 
-    ChaCha20Poly1305::new(key.as_ref().into())
-        .decrypt_in_place_detached(
-            [0u8; 12][..].into(),
-            &[],
-            &mut plaintext.0,
-            enc_ciphertext[NOTE_PLAINTEXT_SIZE..].into(),
-        )
-        .ok()?;
+    let plaintext = D::decrypt_with_key(key, enc_ciphertext);
+    let compact_plaintext = D::convert_to_compact_plaintext(&plaintext);
+    // let mut plaintext =
+    //     NotePlaintextBytes(enc_ciphertext[..NOTE_PLAINTEXT_SIZE].try_into().unwrap());
+    //
+    // ChaCha20Poly1305::new(key.as_ref().into())
+    //     .decrypt_in_place_detached(
+    //         [0u8; 12][..].into(),
+    //         &[],
+    //         &mut plaintext.0,
+    //         enc_ciphertext[NOTE_PLAINTEXT_SIZE..].into(),
+    //     )
+    //     .ok()?;
 
     let (note, to) = parse_note_plaintext_without_memo_ivk(
         domain,
         ivk,
         ephemeral_key,
         &output.cmstar_bytes(),
-        &plaintext.0,
+        &compact_plaintext,
     )?;
     let memo = domain.extract_memo(&plaintext);
 
     Some((note, to, memo))
 }
 
+/// This function only takes in plaintext bytes with the memo removed, as in compact notes.
+/// If working with full notes, first convert to compact note using `convert_to_compact_plaintext`.
 fn parse_note_plaintext_without_memo_ivk<D: Domain>(
     domain: &D,
     ivk: &D::IncomingViewingKey,
     ephemeral_key: &EphemeralKeyBytes,
     cmstar_bytes: &D::ExtractedCommitmentBytes,
-    plaintext: &[u8],
+    plaintext: &D::CompactNotePlaintextBytes,
 ) -> Option<(D::Note, D::Recipient)> {
     let (note, to) = domain.parse_note_plaintext_without_memo_ivk(ivk, plaintext)?;
 
@@ -567,7 +675,12 @@ fn check_note_validity<D: Domain>(
 /// Implements the procedure specified in [`ZIP 307`].
 ///
 /// [`ZIP 307`]: https://zips.z.cash/zip-0307
-pub fn try_compact_note_decryption<D: Domain, Output: ShieldedOutput<D, COMPACT_NOTE_SIZE>>(
+///
+/// This function is only meant to be used with compact notes, not full notes.
+/// If the note is a full note, then this function returns `None`.
+///
+/// For full notes, use 'try_note_decryption` and `try_note_decryption_inner`.
+pub fn try_compact_note_decryption<D: Domain, Output: ShieldedOutput<D>>(
     domain: &D,
     ivk: &D::IncomingViewingKey,
     output: &Output,
@@ -581,19 +694,32 @@ pub fn try_compact_note_decryption<D: Domain, Output: ShieldedOutput<D, COMPACT_
     try_compact_note_decryption_inner(domain, ivk, &ephemeral_key, output, &key)
 }
 
-fn try_compact_note_decryption_inner<D: Domain, Output: ShieldedOutput<D, COMPACT_NOTE_SIZE>>(
+/// This function is only meant to be used with compact notes, not full notes.
+/// If the note is a full note, then this function returns `None`.
+///
+/// For full notes, use 'try_note_decryption` and `try_note_decryption_inner`.
+fn try_compact_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
     domain: &D,
     ivk: &D::IncomingViewingKey,
     ephemeral_key: &EphemeralKeyBytes,
     output: &Output,
     key: &D::SymmetricKey,
 ) -> Option<(D::Note, D::Recipient)> {
-    // Start from block 1 to skip over Poly1305 keying output
-    let mut plaintext = [0; COMPACT_NOTE_SIZE];
-    plaintext.copy_from_slice(output.enc_ciphertext());
-    let mut keystream = ChaCha20::new(key.as_ref().into(), [0u8; 12][..].into());
-    keystream.seek(64);
-    keystream.apply_keystream(&mut plaintext);
+
+    let enc_ciphertext: D::CompactEncNoteCiphertextBytes;
+    if let Some(x) = extract_compact_note_ciphertext(output.enc_ciphertext()) {
+        enc_ciphertext = x;
+    } else {
+        return None;
+    }
+
+    let plaintext = D::decrypt_compact_with_key(key, enc_ciphertext);
+    // // Start from block 1 to skip over Poly1305 keying output
+    // let mut plaintext = [0; COMPACT_NOTE_SIZE];
+    // plaintext.copy_from_slice(output.enc_ciphertext());
+    // let mut keystream = ChaCha20::new(key.as_ref().into(), [0u8; 12][..].into());
+    // keystream.seek(64);
+    // keystream.apply_keystream(&mut plaintext);
 
     parse_note_plaintext_without_memo_ivk(
         domain,
@@ -613,7 +739,10 @@ fn try_compact_note_decryption_inner<D: Domain, Output: ShieldedOutput<D, COMPAC
 /// Implements [Zcash Protocol Specification section 4.19.3][decryptovk].
 ///
 /// [decryptovk]: https://zips.z.cash/protocol/nu5.pdf#decryptovk
-pub fn try_output_recovery_with_ovk<D: Domain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>>(
+///
+/// This function is only meant to be used with full notes, not compact notes.
+/// If the note is a compact note, then this function returns `None`.
+pub fn try_output_recovery_with_ovk<D: Domain, Output: ShieldedOutput<D>>(
     domain: &D,
     ovk: &D::OutgoingViewingKey,
     output: &Output,
@@ -633,13 +762,22 @@ pub fn try_output_recovery_with_ovk<D: Domain, Output: ShieldedOutput<D, ENC_CIP
 /// Implements part of section 4.19.3 of the
 /// [Zcash Protocol Specification](https://zips.z.cash/protocol/nu5.pdf#decryptovk).
 /// For decryption using a Full Viewing Key see [`try_output_recovery_with_ovk`].
-pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>>(
+///
+/// This function is only meant to be used with full notes, not compact notes.
+/// If the note is a compact note, then this function returns `None`.
+pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D>>(
     domain: &D,
     ock: &OutgoingCipherKey,
     output: &Output,
     out_ciphertext: &[u8; OUT_CIPHERTEXT_SIZE],
 ) -> Option<(D::Note, D::Recipient, D::Memo)> {
-    let enc_ciphertext = output.enc_ciphertext();
+
+    let enc_ciphertext: D::EncNoteCiphertextBytes;
+    if let Some(x) = extract_full_note_ciphertext(output.enc_ciphertext()) {
+        enc_ciphertext = x;
+    } else {
+        return None;
+    }
 
     let mut op = OutPlaintextBytes([0; OUT_PLAINTEXT_SIZE]);
     op.0.copy_from_slice(&out_ciphertext[..OUT_PLAINTEXT_SIZE]);
@@ -663,22 +801,24 @@ pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D, ENC_CIP
     // be okay.
     let key = D::kdf(shared_secret, &ephemeral_key);
 
-    let mut plaintext = NotePlaintextBytes([0; NOTE_PLAINTEXT_SIZE]);
-    plaintext
-        .0
-        .copy_from_slice(&enc_ciphertext[..NOTE_PLAINTEXT_SIZE]);
-
-    ChaCha20Poly1305::new(key.as_ref().into())
-        .decrypt_in_place_detached(
-            [0u8; 12][..].into(),
-            &[],
-            &mut plaintext.0,
-            enc_ciphertext[NOTE_PLAINTEXT_SIZE..].into(),
-        )
-        .ok()?;
+    let plaintext = D::decrypt_with_key(&key, enc_ciphertext);
+    let compact_plaintext = D::convert_to_compact_plaintext(&plaintext);
+    // let mut plaintext = NotePlaintextBytes([0; NOTE_PLAINTEXT_SIZE]);
+    // plaintext
+    //     .0
+    //     .copy_from_slice(&enc_ciphertext[..NOTE_PLAINTEXT_SIZE]);
+    //
+    // ChaCha20Poly1305::new(key.as_ref().into())
+    //     .decrypt_in_place_detached(
+    //         [0u8; 12][..].into(),
+    //         &[],
+    //         &mut plaintext.0,
+    //         enc_ciphertext[NOTE_PLAINTEXT_SIZE..].into(),
+    //     )
+    //     .ok()?;
 
     let (note, to) =
-        domain.parse_note_plaintext_without_memo_ovk(&pk_d, &esk, &ephemeral_key, &plaintext)?;
+        domain.parse_note_plaintext_without_memo_ovk(&pk_d, &esk, &ephemeral_key, &compact_plaintext)?;
     let memo = domain.extract_memo(&plaintext);
 
     // ZIP 212: Check that the esk provided to this function is consistent with the esk we

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -42,8 +42,10 @@ pub const COMPACT_NOTE_SIZE: usize = 1 + // version
     11 + // diversifier
     8  + // value
     32; // rseed (or rcm prior to ZIP 212)
-/// The size of [`NotePlaintextBytes`].
-pub const NOTE_PLAINTEXT_SIZE: usize = COMPACT_NOTE_SIZE + 512;
+/// The size of the memo.
+const MEMO_SIZE: usize = 512;
+/// The size of the original encoding of NotePlaintextBytes.
+pub const NOTE_PLAINTEXT_SIZE: usize = COMPACT_NOTE_SIZE + MEMO_SIZE;
 /// The size of [`OutPlaintextBytes`].
 pub const OUT_PLAINTEXT_SIZE: usize = 32 + // pk_d
     32; // esk
@@ -107,24 +109,6 @@ enum NoteValidity {
 pub enum NoteCiphertext<D: Domain> {
     Full(D::EncNoteCiphertextBytes),
     Compact(D::CompactEncNoteCiphertextBytes),
-}
-
-/// Function to extract the full encrypted note ciphertext from the `NoteCiphertext` enum.
-/// Returns `None` if the enum variant is `Compact`.
-pub fn extract_full_note_ciphertext<D: Domain>(nc: NoteCiphertext<D>) -> Option<D::EncNoteCiphertextBytes> {
-    match nc {
-        NoteCiphertext::Full(x) => Some(x),
-        NoteCiphertext::Compact(_) => None,
-    }
-}
-
-/// Function to extract the compact encrypted note ciphertext from the `NoteCiphertext` enum.
-/// Returns `None` if the enum variant is `Full`.
-pub fn extract_compact_note_ciphertext<D: Domain>(nc: NoteCiphertext<D>) -> Option<D::CompactEncNoteCiphertextBytes> {
-    match nc {
-        NoteCiphertext::Full(_) => None,
-        NoteCiphertext::Compact(x) => Some(x),
-    }
 }
 
 /// Trait that encapsulates protocol-specific note encryption types and logic.
@@ -305,12 +289,6 @@ pub trait Domain {
     /// Returns `None` if `out_plaintext` does not contain a valid byte encoding of an
     /// `EphemeralSecretKey`.
     fn extract_esk(out_plaintext: &OutPlaintextBytes) -> Option<Self::EphemeralSecretKey>;
-
-    /// Returns a vector with the bytes of the note plaintext.
-    fn vec_note_plaintext(plaintext: &Self::NotePlaintextBytes) -> Vec<u8>;
-
-    /// Returns a vector with the bytes of the encrypted note ciphertext.
-    fn vec_enc_note_ciphertext(enc_note_ciphertext: &Self::EncNoteCiphertextBytes) -> Vec<u8>;
 
     /// Performs the inner encryption logic given the key and the note plaintext, and returns
     /// the encrypted note ciphertext.
@@ -545,10 +523,9 @@ fn try_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
 ) -> Option<(D::Note, D::Recipient, D::Memo)> {
 
     let enc_ciphertext: D::EncNoteCiphertextBytes;
-    if let Some(x) = extract_full_note_ciphertext(output.enc_ciphertext()) {
-        enc_ciphertext = x;
-    } else {
-        return None;
+    match output.enc_ciphertext() {
+        NoteCiphertext::Full(x) => enc_ciphertext = x,
+        NoteCiphertext::Compact(_) => return None,
     }
 
     let plaintext = D::decrypt_with_key(key, enc_ciphertext);
@@ -650,10 +627,9 @@ fn try_compact_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
 ) -> Option<(D::Note, D::Recipient)> {
 
     let enc_ciphertext: D::CompactEncNoteCiphertextBytes;
-    if let Some(x) = extract_compact_note_ciphertext(output.enc_ciphertext()) {
-        enc_ciphertext = x;
-    } else {
-        return None;
+    match output.enc_ciphertext() {
+        NoteCiphertext::<D>::Compact(x) => enc_ciphertext = x,
+        NoteCiphertext::<D>::Full(_) => return None,
     }
 
     let plaintext = D::decrypt_compact_with_key(key, enc_ciphertext);
@@ -710,10 +686,9 @@ pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D>>(
 ) -> Option<(D::Note, D::Recipient, D::Memo)> {
 
     let enc_ciphertext: D::EncNoteCiphertextBytes;
-    if let Some(x) = extract_full_note_ciphertext(output.enc_ciphertext()) {
-        enc_ciphertext = x;
-    } else {
-        return None;
+    match output.enc_ciphertext() {
+        NoteCiphertext::<D>::Full(x) => enc_ciphertext = x,
+        NoteCiphertext::<D>::Compact(_) => return None,
     }
 
     let mut op = OutPlaintextBytes([0; OUT_PLAINTEXT_SIZE]);

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -122,7 +122,7 @@ pub trait Domain {
     type SharedSecret;
     type SymmetricKey: AsRef<[u8]>;
     type Note;
-    type NotePlaintextBytes;
+    type NotePlaintextBytes: AsMut<[u8]>;
     type EncNoteCiphertextBytes;
     type CompactNotePlaintextBytes;
     type CompactEncNoteCiphertextBytes;
@@ -312,6 +312,8 @@ pub trait Domain {
     ) -> Self::CompactNotePlaintextBytes;
 
     fn convert_to_compact_plaintext(full_note: &Self::NotePlaintextBytes) -> Self::CompactNotePlaintextBytes;
+
+    fn ciphertext_from_enc_plaintext_and_tag(enc_plaintext: Self::NotePlaintextBytes, tag: &[u8]) -> Self::EncNoteCiphertextBytes;
 }
 
 /// Trait that encapsulates protocol-specific batch trial decryption logic.
@@ -446,7 +448,16 @@ impl<D: Domain> NoteEncryption<D> {
         let key = D::kdf(shared_secret, &D::epk_bytes(&self.epk));
         let input = D::note_plaintext_bytes(&self.note, &self.to, &self.memo);
 
-        D::encrypt_with_key(key, input)
+        let mut input_copy = input;
+
+        let tag = ChaCha20Poly1305::new(key.as_ref().into())
+            .encrypt_in_place_detached(
+                [0u8; 12][..].into(),
+                &[],
+                input_copy.as_mut(),
+            )
+            .unwrap();
+        D::ciphertext_from_enc_plaintext_and_tag(input_copy, &tag)
     }
 
     /// Generates `outCiphertext` for this note.

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -314,6 +314,8 @@ pub trait Domain {
     fn convert_to_compact_plaintext(full_note: &Self::NotePlaintextBytes) -> Self::CompactNotePlaintextBytes;
 
     fn ciphertext_from_enc_plaintext_and_tag(enc_plaintext: Self::NotePlaintextBytes, tag: &[u8]) -> Self::EncNoteCiphertextBytes;
+
+    fn separate_tag_from_ciphertext(enc_ciphertext: Self::EncNoteCiphertextBytes) -> (Self::NotePlaintextBytes, [u8; AEAD_TAG_SIZE]);
 }
 
 /// Trait that encapsulates protocol-specific batch trial decryption logic.
@@ -539,7 +541,19 @@ fn try_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
         NoteCiphertext::Compact(_) => return None,
     }
 
-    let plaintext = D::decrypt_with_key(key, enc_ciphertext);
+    let (enc_plaintext, tag) = D::separate_tag_from_ciphertext(enc_ciphertext);
+    let mut plaintext = enc_plaintext;
+
+    ChaCha20Poly1305::new(key.as_ref().into())
+        .decrypt_in_place_detached(
+            [0u8; 12][..].into(),
+            &[],
+            plaintext.as_mut(),
+            &tag.into(),
+        )
+        .ok()?;
+
+    // let plaintext = D::decrypt_with_key(key, enc_ciphertext);
     let compact_plaintext = D::convert_to_compact_plaintext(&plaintext);
 
     let (note, to) = parse_note_plaintext_without_memo_ivk(

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -30,6 +30,14 @@ use chacha20poly1305::{
     KeyInit,
 };
 
+use chacha20::ChaCha20;
+
+use cipher::{
+    KeyIvInit,
+    StreamCipher,
+    StreamCipherSeek,
+};
+
 use rand_core::RngCore;
 use subtle::{Choice, ConstantTimeEq};
 
@@ -124,7 +132,7 @@ pub trait Domain {
     type Note;
     type NotePlaintextBytes: AsMut<[u8]>;
     type EncNoteCiphertextBytes;
-    type CompactNotePlaintextBytes: From<Self::NotePlaintextBytes>;
+    type CompactNotePlaintextBytes: From<Self::NotePlaintextBytes> + AsMut<[u8]>;
     type CompactEncNoteCiphertextBytes;
     type Recipient;
     type DiversifiedTransmissionKey;
@@ -288,30 +296,11 @@ pub trait Domain {
     /// `EphemeralSecretKey`.
     fn extract_esk(out_plaintext: &OutPlaintextBytes) -> Option<Self::EphemeralSecretKey>;
 
-    /// Performs the inner encryption logic given the key and the note plaintext, and returns
-    /// the encrypted note ciphertext.
-    fn encrypt_with_key(
-        key: Self::SymmetricKey,
-        input: Self::NotePlaintextBytes,
-    ) -> Self::EncNoteCiphertextBytes;
-
-    /// Performs the inner decryption logic given the key and the encrypted note ciphertext,
-    /// and returns the note plaintext.
-    fn decrypt_with_key(
-        key: &Self::SymmetricKey,
-        enc_ciphertext: Self::EncNoteCiphertextBytes,
-    ) -> Self::NotePlaintextBytes;
-
-    /// Performs the inner decryption logic for compct notes given the key and the
-    /// compact encrypted note ciphertext, and returns the compact note plaintext.
-    fn decrypt_compact_with_key(
-        key: &Self::SymmetricKey,
-        enc_ciphertext: Self::CompactEncNoteCiphertextBytes,
-    ) -> Self::CompactNotePlaintextBytes;
-
     fn ciphertext_from_enc_plaintext_and_tag(enc_plaintext: Self::NotePlaintextBytes, tag: &[u8]) -> Self::EncNoteCiphertextBytes;
 
     fn separate_tag_from_ciphertext(enc_ciphertext: Self::EncNoteCiphertextBytes) -> (Self::NotePlaintextBytes, [u8; AEAD_TAG_SIZE]);
+
+    fn convert_to_compact_plaintext_type(enc_ciphertext: Self::CompactEncNoteCiphertextBytes) -> Self::CompactNotePlaintextBytes;
 }
 
 /// Trait that encapsulates protocol-specific batch trial decryption logic.
@@ -444,18 +433,16 @@ impl<D: Domain> NoteEncryption<D> {
         let pk_d = D::get_pk_d(&self.note);
         let shared_secret = D::ka_agree_enc(&self.esk, &pk_d);
         let key = D::kdf(shared_secret, &D::epk_bytes(&self.epk));
-        let input = D::note_plaintext_bytes(&self.note, &self.to, &self.memo);
-
-        let mut input_copy = input;
+        let mut input = D::note_plaintext_bytes(&self.note, &self.to, &self.memo);
 
         let tag = ChaCha20Poly1305::new(key.as_ref().into())
             .encrypt_in_place_detached(
                 [0u8; 12][..].into(),
                 &[],
-                input_copy.as_mut(),
+                input.as_mut(),
             )
             .unwrap();
-        D::ciphertext_from_enc_plaintext_and_tag(input_copy, &tag)
+        D::ciphertext_from_enc_plaintext_and_tag(input, &tag)
     }
 
     /// Generates `outCiphertext` for this note.
@@ -652,7 +639,11 @@ fn try_compact_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
         NoteCiphertext::<D>::Full(_) => return None,
     }
 
-    let plaintext = D::decrypt_compact_with_key(key, enc_ciphertext);
+    // Start from block 1 to skip over Poly1305 keying output
+    let mut plaintext = D::convert_to_compact_plaintext_type(enc_ciphertext);
+    let mut keystream = ChaCha20::new(key.as_ref().into(), [0u8; 12][..].into());
+    keystream.seek(64);
+    keystream.apply_keystream(plaintext.as_mut());
 
     parse_note_plaintext_without_memo_ivk(
         domain,
@@ -733,7 +724,17 @@ pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D>>(
     // be okay.
     let key = D::kdf(shared_secret, &ephemeral_key);
 
-    let plaintext = D::decrypt_with_key(&key, enc_ciphertext);
+    let (enc_plaintext, tag) = D::separate_tag_from_ciphertext(enc_ciphertext);
+    let mut plaintext = enc_plaintext;
+
+    ChaCha20Poly1305::new(key.as_ref().into())
+        .decrypt_in_place_detached(
+            [0u8; 12][..].into(),
+            &[],
+            plaintext.as_mut(),
+            &tag.into(),
+        )
+        .ok()?;
 
     let memo = domain.extract_memo(&plaintext);
 

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -24,19 +24,11 @@ extern crate alloc;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-// use core::convert::TryInto;
-
-// use chacha20::{
-//     cipher::{StreamCipher, StreamCipherSeek},
-//     ChaCha20,
-// };
 use chacha20poly1305::{
     aead::AeadInPlace,
     ChaCha20Poly1305,
     KeyInit,
 };
-
-// use cipher::KeyIvInit;
 
 use rand_core::RngCore;
 use subtle::{Choice, ConstantTimeEq};
@@ -109,14 +101,6 @@ enum NoteValidity {
     Invalid,
 }
 
-// /// Enum for the note plaintext.
-// /// The variants represent whether the note is a full note or a compact note.
-// #[derive(Copy, Clone, PartialEq, Eq)]
-// enum NotePlaintext<D: Domain> {
-//     Full(D::NotePlaintextBytes),
-//     Compact(D::CompactNotePlaintextBytes),
-// }
-
 /// Enum for the note ciphertext.
 /// The variants represent whether the encrypted note is a full note or a compact note.
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -124,24 +108,6 @@ pub enum NoteCiphertext<D: Domain> {
     Full(D::EncNoteCiphertextBytes),
     Compact(D::CompactEncNoteCiphertextBytes),
 }
-
-// /// Function to extract the full note plaintext from the `NotePlaintext` enum.
-// /// Returns `None` if the enum variant is `Compact`.
-// pub fn extract_full_note_plaintext<D: Domain>(np: NotePlaintext<D>) -> Option<D::NotePlaintextBytes> {
-//     match np {
-//         NotePlaintext::Full(x) => Some(x),
-//         NotePlaintext::Compact(_) => None,
-//     }
-// }
-
-// /// Function to extract the compact note plaintext from the `NotePlaintext` enum.
-// /// Returns `None` if the enum variant is `Full`.
-// pub fn extract_compact_note_plaintext<D: Domain>(np: NotePlaintext<D>) -> Option<D::CompactNotePlaintextBytes> {
-//     match np {
-//         NotePlaintext::Full(_) => None,
-//         NotePlaintext::Compact(x) => Some(x),
-//     }
-// }
 
 /// Function to extract the full encrypted note ciphertext from the `NoteCiphertext` enum.
 /// Returns `None` if the enum variant is `Compact`.
@@ -503,18 +469,6 @@ impl<D: Domain> NoteEncryption<D> {
         let input = D::note_plaintext_bytes(&self.note, &self.to, &self.memo);
 
         D::encrypt_with_key(key, input)
-        // let mut output = [0u8; ENC_CIPHERTEXT_SIZE];
-        // output[..NOTE_PLAINTEXT_SIZE].copy_from_slice(&input.0);
-        // let tag = ChaCha20Poly1305::new(key.as_ref().into())
-        //     .encrypt_in_place_detached(
-        //         [0u8; 12][..].into(),
-        //         &[],
-        //         &mut output[..NOTE_PLAINTEXT_SIZE],
-        //     )
-        //     .unwrap();
-        // output[NOTE_PLAINTEXT_SIZE..].copy_from_slice(&tag);
-        //
-        // output
     }
 
     /// Generates `outCiphertext` for this note.
@@ -599,17 +553,6 @@ fn try_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
 
     let plaintext = D::decrypt_with_key(key, enc_ciphertext);
     let compact_plaintext = D::convert_to_compact_plaintext(&plaintext);
-    // let mut plaintext =
-    //     NotePlaintextBytes(enc_ciphertext[..NOTE_PLAINTEXT_SIZE].try_into().unwrap());
-    //
-    // ChaCha20Poly1305::new(key.as_ref().into())
-    //     .decrypt_in_place_detached(
-    //         [0u8; 12][..].into(),
-    //         &[],
-    //         &mut plaintext.0,
-    //         enc_ciphertext[NOTE_PLAINTEXT_SIZE..].into(),
-    //     )
-    //     .ok()?;
 
     let (note, to) = parse_note_plaintext_without_memo_ivk(
         domain,
@@ -714,12 +657,6 @@ fn try_compact_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
     }
 
     let plaintext = D::decrypt_compact_with_key(key, enc_ciphertext);
-    // // Start from block 1 to skip over Poly1305 keying output
-    // let mut plaintext = [0; COMPACT_NOTE_SIZE];
-    // plaintext.copy_from_slice(output.enc_ciphertext());
-    // let mut keystream = ChaCha20::new(key.as_ref().into(), [0u8; 12][..].into());
-    // keystream.seek(64);
-    // keystream.apply_keystream(&mut plaintext);
 
     parse_note_plaintext_without_memo_ivk(
         domain,
@@ -803,19 +740,6 @@ pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D>>(
 
     let plaintext = D::decrypt_with_key(&key, enc_ciphertext);
     let compact_plaintext = D::convert_to_compact_plaintext(&plaintext);
-    // let mut plaintext = NotePlaintextBytes([0; NOTE_PLAINTEXT_SIZE]);
-    // plaintext
-    //     .0
-    //     .copy_from_slice(&enc_ciphertext[..NOTE_PLAINTEXT_SIZE]);
-    //
-    // ChaCha20Poly1305::new(key.as_ref().into())
-    //     .decrypt_in_place_detached(
-    //         [0u8; 12][..].into(),
-    //         &[],
-    //         &mut plaintext.0,
-    //         enc_ciphertext[NOTE_PLAINTEXT_SIZE..].into(),
-    //     )
-    //     .ok()?;
 
     let (note, to) =
         domain.parse_note_plaintext_without_memo_ovk(&pk_d, &esk, &ephemeral_key, &compact_plaintext)?;

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -124,7 +124,7 @@ pub trait Domain {
     type Note;
     type NotePlaintextBytes: AsMut<[u8]>;
     type EncNoteCiphertextBytes;
-    type CompactNotePlaintextBytes;
+    type CompactNotePlaintextBytes: From<Self::NotePlaintextBytes>;
     type CompactEncNoteCiphertextBytes;
     type Recipient;
     type DiversifiedTransmissionKey;
@@ -238,7 +238,6 @@ pub trait Domain {
     /// [ZIP 212]: https://zips.z.cash/zip-0212
     ///
     /// This function only takes in plaintext bytes with the memo removed, as in compact notes.
-    /// If working with full notes, first convert to compact note using `convert_to_compact_plaintext`.
     fn parse_note_plaintext_without_memo_ivk(
         &self,
         ivk: &Self::IncomingViewingKey,
@@ -261,7 +260,6 @@ pub trait Domain {
     /// [ZIP 212]: https://zips.z.cash/zip-0212
     ///
     /// This function only takes in plaintext bytes with the memo removed, as in compact notes.
-    /// If working with full notes, first convert to compact note using `convert_to_compact_plaintext`.
     fn parse_note_plaintext_without_memo_ovk(
         &self,
         pk_d: &Self::DiversifiedTransmissionKey,
@@ -310,8 +308,6 @@ pub trait Domain {
         key: &Self::SymmetricKey,
         enc_ciphertext: Self::CompactEncNoteCiphertextBytes,
     ) -> Self::CompactNotePlaintextBytes;
-
-    fn convert_to_compact_plaintext(full_note: &Self::NotePlaintextBytes) -> Self::CompactNotePlaintextBytes;
 
     fn ciphertext_from_enc_plaintext_and_tag(enc_plaintext: Self::NotePlaintextBytes, tag: &[u8]) -> Self::EncNoteCiphertextBytes;
 
@@ -554,22 +550,21 @@ fn try_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
         .ok()?;
 
     // let plaintext = D::decrypt_with_key(key, enc_ciphertext);
-    let compact_plaintext = D::convert_to_compact_plaintext(&plaintext);
+
+    let memo = domain.extract_memo(&plaintext);
 
     let (note, to) = parse_note_plaintext_without_memo_ivk(
         domain,
         ivk,
         ephemeral_key,
         &output.cmstar_bytes(),
-        &compact_plaintext,
+        &plaintext.into(),
     )?;
-    let memo = domain.extract_memo(&plaintext);
 
     Some((note, to, memo))
 }
 
 /// This function only takes in plaintext bytes with the memo removed, as in compact notes.
-/// If working with full notes, first convert to compact note using `convert_to_compact_plaintext`.
 fn parse_note_plaintext_without_memo_ivk<D: Domain>(
     domain: &D,
     ivk: &D::IncomingViewingKey,
@@ -739,11 +734,11 @@ pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D>>(
     let key = D::kdf(shared_secret, &ephemeral_key);
 
     let plaintext = D::decrypt_with_key(&key, enc_ciphertext);
-    let compact_plaintext = D::convert_to_compact_plaintext(&plaintext);
+
+    let memo = domain.extract_memo(&plaintext);
 
     let (note, to) =
-        domain.parse_note_plaintext_without_memo_ovk(&pk_d, &esk, &ephemeral_key, &compact_plaintext)?;
-    let memo = domain.extract_memo(&plaintext);
+        domain.parse_note_plaintext_without_memo_ovk(&pk_d, &esk, &ephemeral_key, &plaintext.into())?;
 
     // ZIP 212: Check that the esk provided to this function is consistent with the esk we
     // can derive from the note.


### PR DESCRIPTION
This has been done by 

- removing the `NotePlaintextBytes` struct and creating new types for `NotePlaintextBytes` and `CompactNotePlaintextBytes` in the `Domain` trait. This allows each implementation to set its choice of these data structures.
- adding the `EncNoteCiphertextByes` and `CompactEncNoteCiphertextBytes` types in the `Domain` trait. This replaces the use of byte arrays `[u8]` to represent encrypted note ciphertexts with the use of specific data structures that can be varied per implementation.
- Various helper functions are added for access.
- The core of the encryption and decryption that will vary based on the data structure being used has also been pulled into the `Domain` trait for independent implementation 
- The existing functions have been updated to work with the above changes.