### PR TITLE
Update `zcash_note_encryption` to support variable note plaintext and encrypted note ciphertext sizes (`orchard` compatible)

### DIFF
--- a/components/zcash_note_encryption/src/batch.rs
+++ b/components/zcash_note_encryption/src/batch.rs
@@ -3,8 +3,10 @@
 use alloc::vec::Vec; // module is alloc only
 
 use crate::{
-    try_compact_note_decryption_inner, try_note_decryption_inner, BatchDomain, EphemeralKeyBytes,
-    ShieldedOutput, COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE,
+    try_compact_note_decryption_inner, try_note_decryption_inner,
+    BatchDomain, EphemeralKeyBytes,
+    ShieldedOutput,
+    // COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE,
 };
 
 /// Trial decryption of a batch of notes with a set of recipients.
@@ -16,7 +18,7 @@ use crate::{
 /// provided, along with the index in the `ivks` slice associated with
 /// the IVK that successfully decrypted the output.
 #[allow(clippy::type_complexity)]
-pub fn try_note_decryption<D: BatchDomain, Output: ShieldedOutput<D, ENC_CIPHERTEXT_SIZE>>(
+pub fn try_note_decryption<D: BatchDomain, Output: ShieldedOutput<D>>(
     ivks: &[D::IncomingViewingKey],
     outputs: &[(D, Output)],
 ) -> Vec<Option<((D::Note, D::Recipient, D::Memo), usize)>> {
@@ -32,14 +34,14 @@ pub fn try_note_decryption<D: BatchDomain, Output: ShieldedOutput<D, ENC_CIPHERT
 /// provided, along with the index in the `ivks` slice associated with
 /// the IVK that successfully decrypted the output.
 #[allow(clippy::type_complexity)]
-pub fn try_compact_note_decryption<D: BatchDomain, Output: ShieldedOutput<D, COMPACT_NOTE_SIZE>>(
+pub fn try_compact_note_decryption<D: BatchDomain, Output: ShieldedOutput<D>>(
     ivks: &[D::IncomingViewingKey],
     outputs: &[(D, Output)],
 ) -> Vec<Option<((D::Note, D::Recipient), usize)>> {
     batch_note_decryption(ivks, outputs, try_compact_note_decryption_inner)
 }
 
-fn batch_note_decryption<D: BatchDomain, Output: ShieldedOutput<D, CS>, F, FR, const CS: usize>(
+fn batch_note_decryption<D: BatchDomain, Output: ShieldedOutput<D>, F, FR>(
     ivks: &[D::IncomingViewingKey],
     outputs: &[(D, Output)],
     decrypt_inner: F,

--- a/components/zcash_note_encryption/src/batch.rs
+++ b/components/zcash_note_encryption/src/batch.rs
@@ -6,7 +6,6 @@ use crate::{
     try_compact_note_decryption_inner, try_note_decryption_inner,
     BatchDomain, EphemeralKeyBytes,
     ShieldedOutput,
-    // COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE,
 };
 
 /// Trial decryption of a batch of notes with a set of recipients.

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -104,14 +104,6 @@ enum NoteValidity {
     Invalid,
 }
 
-// /// Enum for the note plaintext.
-// /// The variants represent whether the note is a full note or a compact note.
-// #[derive(Copy, Clone, PartialEq, Eq)]
-// enum NotePlaintext<D: Domain> {
-//     Full(D::NotePlaintextBytes),
-//     Compact(D::CompactNotePlaintextBytes),
-// }
-
 /// Enum for the note ciphertext.
 /// The variants represent whether the encrypted note is a full note or a compact note.
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -119,24 +111,6 @@ pub enum NoteCiphertext<D: Domain> {
     Full(D::EncNoteCiphertextBytes),
     Compact(D::CompactEncNoteCiphertextBytes),
 }
-
-// /// Function to extract the full note plaintext from the `NotePlaintext` enum.
-// /// Returns `None` if the enum variant is `Compact`.
-// pub fn extract_full_note_plaintext<D: Domain>(np: NotePlaintext<D>) -> Option<D::NotePlaintextBytes> {
-//     match np {
-//         NotePlaintext::Full(x) => Some(x),
-//         NotePlaintext::Compact(_) => None,
-//     }
-// }
-
-// /// Function to extract the compact note plaintext from the `NotePlaintext` enum.
-// /// Returns `None` if the enum variant is `Full`.
-// pub fn extract_compact_note_plaintext<D: Domain>(np: NotePlaintext<D>) -> Option<D::CompactNotePlaintextBytes> {
-//     match np {
-//         NotePlaintext::Full(_) => None,
-//         NotePlaintext::Compact(x) => Some(x),
-//     }
-// }
 
 /// Function to extract the full encrypted note ciphertext from the `NoteCiphertext` enum.
 /// Returns `None` if the enum variant is `Compact`.
@@ -542,18 +516,6 @@ impl<D: Domain> NoteEncryption<D> {
         let input = D::note_plaintext_bytes(&self.note, &self.to, &self.memo);
 
         D::encrypt_with_key(key, input)
-        // let mut output = [0u8; ENC_CIPHERTEXT_SIZE];
-        // output[..NOTE_PLAINTEXT_SIZE].copy_from_slice(&input.0);
-        // let tag = ChaCha20Poly1305::new(key.as_ref().into())
-        //     .encrypt_in_place_detached(
-        //         [0u8; 12][..].into(),
-        //         &[],
-        //         &mut output[..NOTE_PLAINTEXT_SIZE],
-        //     )
-        //     .unwrap();
-        // output[NOTE_PLAINTEXT_SIZE..].copy_from_slice(&tag);
-        //
-        // output
     }
 
     /// Generates `outCiphertext` for this note.
@@ -638,17 +600,6 @@ fn try_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
 
     let plaintext = D::decrypt_with_key(key, enc_ciphertext);
     let compact_plaintext = D::convert_to_compact_plaintext(&plaintext);
-    // let mut plaintext =
-    //     NotePlaintextBytes(enc_ciphertext[..NOTE_PLAINTEXT_SIZE].try_into().unwrap());
-    //
-    // ChaCha20Poly1305::new(key.as_ref().into())
-    //     .decrypt_in_place_detached(
-    //         [0u8; 12][..].into(),
-    //         &[],
-    //         &mut plaintext.0,
-    //         enc_ciphertext[NOTE_PLAINTEXT_SIZE..].into(),
-    //     )
-    //     .ok()?;
 
     let (note, to) = parse_note_plaintext_without_memo_ivk(
         domain,
@@ -753,12 +704,6 @@ fn try_compact_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
     }
 
     let plaintext = D::decrypt_compact_with_key(key, enc_ciphertext);
-    // // Start from block 1 to skip over Poly1305 keying output
-    // let mut plaintext = [0; COMPACT_NOTE_SIZE];
-    // plaintext.copy_from_slice(output.enc_ciphertext());
-    // let mut keystream = ChaCha20::new(key.as_ref().into(), [0u8; 12][..].into());
-    // keystream.seek(64);
-    // keystream.apply_keystream(&mut plaintext);
 
     parse_note_plaintext_without_memo_ivk(
         domain,
@@ -842,19 +787,6 @@ pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D>>(
 
     let plaintext = D::decrypt_with_key(&key, enc_ciphertext);
     let compact_plaintext = D::convert_to_compact_plaintext(&plaintext);
-    // let mut plaintext = NotePlaintextBytes([0; NOTE_PLAINTEXT_SIZE]);
-    // plaintext
-    //     .0
-    //     .copy_from_slice(&enc_ciphertext[..NOTE_PLAINTEXT_SIZE]);
-    //
-    // ChaCha20Poly1305::new(key.as_ref().into())
-    //     .decrypt_in_place_detached(
-    //         [0u8; 12][..].into(),
-    //         &[],
-    //         &mut plaintext.0,
-    //         enc_ciphertext[NOTE_PLAINTEXT_SIZE..].into(),
-    //     )
-    //     .ok()?;
 
     let (note, to) =
         domain.parse_note_plaintext_without_memo_ovk(&pk_d, &esk, &ephemeral_key, &compact_plaintext)?;

--- a/components/zcash_note_encryption/src/lib.rs
+++ b/components/zcash_note_encryption/src/lib.rs
@@ -283,9 +283,9 @@ pub trait Domain {
     /// `EphemeralSecretKey`.
     fn extract_esk(out_plaintext: &OutPlaintextBytes) -> Option<Self::EphemeralSecretKey>;
 
-    fn separate_tag_from_ciphertext(enc_ciphertext: Self::EncNoteCiphertextBytes) -> (Self::NotePlaintextBytes, [u8; AEAD_TAG_SIZE]);
+    fn separate_tag_from_ciphertext(enc_ciphertext: &Self::EncNoteCiphertextBytes) -> (Self::NotePlaintextBytes, [u8; AEAD_TAG_SIZE]);
 
-    fn convert_to_compact_plaintext_type(enc_ciphertext: Self::CompactEncNoteCiphertextBytes) -> Self::CompactNotePlaintextBytes;
+    fn convert_to_compact_plaintext_type(enc_ciphertext: &Self::CompactEncNoteCiphertextBytes) -> Self::CompactNotePlaintextBytes;
 }
 
 /// Trait that encapsulates protocol-specific batch trial decryption logic.
@@ -340,11 +340,11 @@ pub trait ShieldedOutput<D: Domain> {
     fn cmstar_bytes(&self) -> D::ExtractedCommitmentBytes;
 
     /// Exposes the note ciphertext of the output. Returns `None` if the output is compact.
-    fn enc_ciphertext(&self) -> Option<D::EncNoteCiphertextBytes>;
+    fn enc_ciphertext(&self) -> Option<&D::EncNoteCiphertextBytes>;
 
     /// Exposes the note ciphertext of the output in the compact note context.
     /// This always returns a value, since a full note ciphertext can be truncated to a compact ciphertext.
-    fn enc_ciphertext_compact(&self) -> D::CompactEncNoteCiphertextBytes;
+    fn enc_ciphertext_compact(&self) -> &D::CompactEncNoteCiphertextBytes;
 }
 
 /// A struct containing context required for encrypting Sapling and Orchard notes.
@@ -551,7 +551,7 @@ fn try_note_decryption_inner<D: Domain, Output: ShieldedOutput<D>>(
     key: &D::SymmetricKey,
 ) -> Option<(D::Note, D::Recipient, D::Memo)> {
 
-    let enc_ciphertext: D::EncNoteCiphertextBytes;
+    let enc_ciphertext: &D::EncNoteCiphertextBytes;
     match output.enc_ciphertext() {
         Some(x) => enc_ciphertext = x,
         None                                    => return None,
@@ -723,7 +723,7 @@ pub fn try_output_recovery_with_ock<D: Domain, Output: ShieldedOutput<D>>(
     out_ciphertext: &[u8; OUT_CIPHERTEXT_SIZE],
 ) -> Option<(D::Note, D::Recipient, D::Memo)> {
 
-    let enc_ciphertext: D::EncNoteCiphertextBytes;
+    let enc_ciphertext: &D::EncNoteCiphertextBytes;
     match output.enc_ciphertext() {
         Some(x) => enc_ciphertext = x,
         None                                    => return None,


### PR DESCRIPTION
This has been done by

- removing the `NotePlaintextBytes` struct and creating new types for `NotePlaintextBytes` and `CompactNotePlaintextBytes` in the `Domain` trait. This allows each implementation to set its choice of these data structures.
- adding the `EncNoteCiphertextByes` and `CompactEncNoteCiphertextBytes` types in the `Domain` trait. This replaces the use of byte arrays (`[u8]`) to represent encrypted note ciphertexts with the use of specific data structures that can be varied per implementation.
- Various helper functions are added for access.
- The core of the encryption and decryption that will vary based on the data structure being used has also been pulled into the Domain trait for independent implementation - this has been done with the aim of minimizing duplication of code.
- The existing functions have been updated to work with the above changes.

Note that this is 