### PR TITLE
Pin winnow and inferno dependencies to resolve version and compilation conflicts

### DIFF
--- a/zcash_history/Cargo.toml
+++ b/zcash_history/Cargo.toml
@@ -14,6 +14,10 @@ assert_matches = "1.3.0"
 quickcheck = "0.9"
 
 [dependencies]
+# FIXME: Although winnow isn't used directly, it's deeply needed in the dependency tree. The latest version of winnow
+# causes a build issue because it enforces the use of Rust v1.64.0, while this crate is tied to v1.61.0.
+# Therefore, as a temporary fix, winnow has been added here to pin it to an older version that doesn't require Rust v1.64.0
+winnow = "=0.4.1"  
 primitive-types = "0.11"
 byteorder = "1"
 blake2 = { package = "blake2b_simd", version = "1" }

--- a/zcash_history/Cargo.toml
+++ b/zcash_history/Cargo.toml
@@ -14,10 +14,8 @@ assert_matches = "1.3.0"
 quickcheck = "0.9"
 
 [dependencies]
-# FIXME: Although winnow isn't used directly, it's deeply needed in the dependency tree. The latest version of winnow
-# causes a build issue because it enforces the use of Rust v1.64.0, while this crate is tied to v1.61.0.
-# Therefore, as a temporary fix, winnow has been added here to pin it to an older version that doesn't require Rust v1.64.0
-winnow = "=0.4.1"  
+# TODO: Pined until we move to rust v1.64.0 or above to support winnow > 0.4.1
+winnow = "=0.4.1"
 primitive-types = "0.11"
 byteorder = "1"
 blake2 = { package = "blake2b_simd", version = "1" }

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -37,6 +37,11 @@ criterion = "0.3"
 rand_xorshift = "0.3"
 
 [target.'cfg(unix)'.dev-dependencies]
+# FIXME: The `inferno` crate isn't a direct dependency, but is deeply nested in the dependency tree.
+# The latest version (0.11.15) of `inferno` causes a compilation error. Therefore, as a temporary fix,
+# `inferno` is added here to pin it to the previous version (0.11.14), which doesn't cause the compilation
+# error.
+inferno = "=0.11.14"
 pprof = { version = "0.9", features = ["criterion", "flamegraph"] } # MSRV 1.56
 
 [features]

--- a/zcash_proofs/Cargo.toml
+++ b/zcash_proofs/Cargo.toml
@@ -37,10 +37,7 @@ criterion = "0.3"
 rand_xorshift = "0.3"
 
 [target.'cfg(unix)'.dev-dependencies]
-# FIXME: The `inferno` crate isn't a direct dependency, but is deeply nested in the dependency tree.
-# The latest version (0.11.15) of `inferno` causes a compilation error. Therefore, as a temporary fix,
-# `inferno` is added here to pin it to the previous version (0.11.14), which doesn't cause the compilation
-# error.
+# TODO: Pined until inferno 0.11.15 is fixed from compilation errors
 inferno = "=0.11.14"
 pprof = { version = "0.9", features = ["criterion", "flamegraph"] } # MSRV 1.56
 


### PR DESCRIPTION
This PR addresses build issues within the `librustzcash` repository.

In the `zcash_history` crate, the `winnow` dependency has been pinned to an older version. The latest version of `winnow` enforces the use of Rust v1.64.0, but the `zcash_history` crate is tied to Rust v1.61.0. This mismatch was causing build problems, which have now been resolved by this change.

The `inferno` dependency, which is used in the `zcash_proofs` crate among possibly others, has also been pinned to an older version. The latest version of `inferno` (0.11.15) was causing a compilation error. By pinning it to version 0.11.14, this issue has been resolved.

These changes are temporary fixes, and should be revisited once the Rust version used in the `librustzcash` repository is updated or the dependencies resolve their respective issues.
