### PR TITLE
Utilize backward-compatible Orchard crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,7 +459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 1.8.2",
 ]
 
 [[package]]
@@ -487,6 +493,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
@@ -598,6 +610,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,14 +651,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -642,6 +691,25 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "equihash"
@@ -816,6 +884,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -893,6 +962,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "half"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "halo2_gadgets"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,7 +980,24 @@ dependencies = [
  "bitvec",
  "ff",
  "group",
- "halo2_proofs",
+ "halo2_proofs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "pasta_curves",
+ "rand",
+ "subtle",
+ "uint",
+]
+
+[[package]]
+name = "halo2_gadgets"
+version = "0.3.0"
+source = "git+https://github.com/QED-it/halo2?branch=orchardzsa-backward-compatability#4cc147385e7cf106b9fab6d6951d66a343899e38"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "ff",
+ "group",
+ "halo2_proofs 0.3.0 (git+https://github.com/QED-it/halo2?branch=orchardzsa-backward-compatability)",
  "lazy_static",
  "pasta_curves",
  "rand",
@@ -921,6 +1016,21 @@ name = "halo2_proofs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b867a8d9bbb85fca76fff60652b5cd19b853a1c4d0665cb89bee68b18d2caf0"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "halo2_legacy_pdqsort",
+ "maybe-rayon",
+ "pasta_curves",
+ "rand_core",
+ "tracing",
+]
+
+[[package]]
+name = "halo2_proofs"
+version = "0.3.0"
+source = "git+https://github.com/QED-it/halo2?branch=orchardzsa-backward-compatability#4cc147385e7cf106b9fab6d6951d66a343899e38"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -1201,6 +1311,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
+]
+
+[[package]]
 name = "known-folders"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
@@ -1470,6 +1594,36 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "orchard"
+version = "0.5.0"
+source = "git+https://github.com/QED-it/orchard?branch=orchardzsa-backward-compatability#e2268a175ff6d95d004315e5f9179e3b34d1e518"
+dependencies = [
+ "aes",
+ "bitvec",
+ "blake2b_simd",
+ "ff",
+ "fpe",
+ "group",
+ "half 2.2.1",
+ "halo2_gadgets 0.3.0 (git+https://github.com/QED-it/halo2?branch=orchardzsa-backward-compatability)",
+ "halo2_proofs 0.3.0 (git+https://github.com/QED-it/halo2?branch=orchardzsa-backward-compatability)",
+ "hex",
+ "incrementalmerkletree",
+ "k256",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "pasta_curves",
+ "proptest",
+ "rand",
+ "reddsa",
+ "serde",
+ "subtle",
+ "tracing",
+ "zcash_note_encryption 0.4.0 (git+https://github.com/QED-it/zcash_note_encryption?branch=zsa1)",
+]
+
+[[package]]
+name = "orchard"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d31e68534df32024dcc89a8390ec6d7bef65edd87d91b45cfb481a2eb2d77c5"
@@ -1480,8 +1634,8 @@ dependencies = [
  "ff",
  "fpe",
  "group",
- "halo2_gadgets",
- "halo2_proofs",
+ "halo2_gadgets 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "halo2_proofs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "incrementalmerkletree",
  "lazy_static",
@@ -1618,6 +1772,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1962,6 +2126,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,6 +2287,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "secp256k1"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,6 +2384,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,6 +2433,16 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -2963,7 +3171,7 @@ dependencies = [
  "jubjub",
  "memuse",
  "nom",
- "orchard",
+ "orchard 0.6.0",
  "percent-encoding",
  "proptest",
  "prost",
@@ -3076,6 +3284,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_note_encryption"
+version = "0.4.0"
+source = "git+https://github.com/QED-it/zcash_note_encryption?branch=zsa1#e14dab6945177815f2b13fbee9c61e12caa96e5a"
+dependencies = [
+ "chacha20",
+ "chacha20poly1305",
+ "cipher",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "zcash_primitives"
 version = "0.13.0-rc.1"
 dependencies = [
@@ -3100,7 +3320,7 @@ dependencies = [
  "lazy_static",
  "memuse",
  "nonempty",
- "orchard",
+ "orchard 0.5.0",
  "pprof",
  "proptest",
  "rand",
@@ -3142,9 +3362,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,31 +973,13 @@ dependencies = [
 [[package]]
 name = "halo2_gadgets"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126a150072b0c38c7b573fe3eaf0af944a7fed09e154071bf2436d3f016f7230"
-dependencies = [
- "arrayvec",
- "bitvec",
- "ff",
- "group",
- "halo2_proofs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static",
- "pasta_curves",
- "rand",
- "subtle",
- "uint",
-]
-
-[[package]]
-name = "halo2_gadgets"
-version = "0.3.0"
 source = "git+https://github.com/QED-it/halo2?branch=orchardzsa-backward-compatability#4cc147385e7cf106b9fab6d6951d66a343899e38"
 dependencies = [
  "arrayvec",
  "bitvec",
  "ff",
  "group",
- "halo2_proofs 0.3.0 (git+https://github.com/QED-it/halo2?branch=orchardzsa-backward-compatability)",
+ "halo2_proofs",
  "lazy_static",
  "pasta_curves",
  "rand",
@@ -1010,22 +992,6 @@ name = "halo2_legacy_pdqsort"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47716fe1ae67969c5e0b2ef826f32db8c3be72be325e1aa3c1951d06b5575ec5"
-
-[[package]]
-name = "halo2_proofs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b867a8d9bbb85fca76fff60652b5cd19b853a1c4d0665cb89bee68b18d2caf0"
-dependencies = [
- "blake2b_simd",
- "ff",
- "group",
- "halo2_legacy_pdqsort",
- "maybe-rayon",
- "pasta_curves",
- "rand_core",
- "tracing",
-]
 
 [[package]]
 name = "halo2_proofs"
@@ -1595,7 +1561,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "orchard"
 version = "0.5.0"
-source = "git+https://github.com/QED-it/orchard?branch=orchardzsa-backward-compatability#e2268a175ff6d95d004315e5f9179e3b34d1e518"
+source = "git+https://github.com/QED-it/orchard?branch=orchardzsa-backward-compatability#53d65182a71cd053f17c1fd15d5eb0671e397ac2"
 dependencies = [
  "aes",
  "bitvec",
@@ -1604,8 +1570,8 @@ dependencies = [
  "fpe",
  "group",
  "half 2.2.1",
- "halo2_gadgets 0.3.0 (git+https://github.com/QED-it/halo2?branch=orchardzsa-backward-compatability)",
- "halo2_proofs 0.3.0 (git+https://github.com/QED-it/halo2?branch=orchardzsa-backward-compatability)",
+ "halo2_gadgets",
+ "halo2_proofs",
  "hex",
  "incrementalmerkletree",
  "k256",
@@ -1620,35 +1586,6 @@ dependencies = [
  "subtle",
  "tracing",
  "zcash_note_encryption 0.4.0 (git+https://github.com/QED-it/zcash_note_encryption?branch=zsa1)",
-]
-
-[[package]]
-name = "orchard"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d31e68534df32024dcc89a8390ec6d7bef65edd87d91b45cfb481a2eb2d77c5"
-dependencies = [
- "aes",
- "bitvec",
- "blake2b_simd",
- "ff",
- "fpe",
- "group",
- "halo2_gadgets 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "halo2_proofs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex",
- "incrementalmerkletree",
- "lazy_static",
- "memuse",
- "nonempty",
- "pasta_curves",
- "proptest",
- "rand",
- "reddsa",
- "serde",
- "subtle",
- "tracing",
- "zcash_note_encryption 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3171,7 +3108,7 @@ dependencies = [
  "jubjub",
  "memuse",
  "nom",
- "orchard 0.6.0",
+ "orchard",
  "percent-encoding",
  "proptest",
  "prost",
@@ -3320,7 +3257,7 @@ dependencies = [
  "lazy_static",
  "memuse",
  "nonempty",
- "orchard 0.5.0",
+ "orchard",
  "pprof",
  "proptest",
  "rand",

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -54,7 +54,7 @@ subtle = "2.2.3"
 # - Shielded protocols
 bls12_381 = "0.8"
 group = "0.13"
-orchard = { version = "0.6", default-features = false }
+orchard = { git = "https://github.com/QED-it/orchard", branch = "orchardzsa-backward-compatability", default-features = false }
 
 # - Note commitment trees
 incrementalmerkletree = "0.5"

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -44,7 +44,7 @@ ff = "0.13"
 group = { version = "0.13", features = ["wnaf-memuse"] }
 jubjub = "0.10"
 nonempty = "0.7"
-orchard = { version = "0.6", default-features = false }
+orchard = { git = "https://github.com/QED-it/orchard", branch = "orchardzsa-backward-compatability", default-features = false }
 
 # - Note Commitment Trees
 incrementalmerkletree = { version = "0.5", features = ["legacy-api"] }
@@ -92,7 +92,7 @@ incrementalmerkletree = { version = "0.5", features = ["legacy-api", "test-depen
 proptest = "1.0.0"
 assert_matches = "1.3.0"
 rand_xorshift = "0.3"
-orchard = { version = "0.6", default-features = false, features = ["test-dependencies"] }
+orchard = { git = "https://github.com/QED-it/orchard", branch = "orchardzsa-backward-compatability", default-features = false, features = ["test-dependencies"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.11", features = ["criterion", "flamegraph"] } # MSRV 1.56

--- a/zcash_primitives/src/transaction/components.rs
+++ b/zcash_primitives/src/transaction/components.rs
@@ -1,12 +1,12 @@
 //! Structs representing the components within Zcash transactions.
 
 pub mod amount;
+pub mod note;
 pub mod orchard;
 pub mod sapling;
 pub mod sprout;
 pub mod transparent;
 pub mod tze;
-pub mod note;
 
 pub use self::{
     amount::Amount,

--- a/zcash_primitives/src/transaction/components/note.rs
+++ b/zcash_primitives/src/transaction/components/note.rs
@@ -1,10 +1,10 @@
+use crate::transaction::components::orchard::read_nullifier;
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use orchard::note::{AssetBase, Nullifier, RandomSeed};
+use orchard::value::NoteValue;
+use orchard::{Address, Note};
 use std::io;
 use std::io::{Read, Write};
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use orchard::{Address, Note};
-use orchard::note::{Nullifier, RandomSeed};
-use orchard::value::NoteValue;
-use crate::transaction::components::orchard::read_nullifier;
 
 /// This will be a part of the 'issuance' component in ZSA release
 fn read_recipient<R: Read>(mut reader: R) -> io::Result<Address> {
@@ -27,10 +27,11 @@ pub fn read_note<R: Read>(mut reader: R) -> io::Result<Note> {
     Ok(Option::from(Note::from_parts(
         recipient,
         NoteValue::from_raw(value),
+        AssetBase::native(), // FIXME: pass burns here for ZSA
         rho,
         rseed,
     ))
-        .unwrap())
+    .unwrap())
 }
 
 pub fn write_note<W: Write>(note: &Note, writer: &mut W) -> io::Result<()> {

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -7,6 +7,7 @@ use nonempty::NonEmpty;
 use orchard::{
     bundle::{Authorization, Authorized, Flags},
     note::{ExtractedNoteCommitment, Nullifier, TransmittedNoteCiphertext},
+    note_encryption_vanilla::{NoteCiphertextBytes, OrchardDomainVanilla, ENC_CIPHERTEXT_SIZE},
     primitives::redpallas::{self, SigType, Signature, SpendAuth, VerificationKey},
     value::ValueCommitment,
     Action, Anchor,
@@ -47,7 +48,7 @@ impl MapAuth<Authorized, Authorized> for () {
 /// Reads an [`orchard::Bundle`] from a v5 transaction format.
 pub fn read_v5_bundle<R: Read>(
     mut reader: R,
-) -> io::Result<Option<orchard::Bundle<Authorized, Amount>>> {
+) -> io::Result<Option<orchard::Bundle<Authorized, Amount, OrchardDomainVanilla>>> {
     #[allow(clippy::redundant_closure)]
     let actions_without_auth = Vector::read(&mut reader, |r| read_action_without_auth(r))?;
     if actions_without_auth.is_empty() {
@@ -75,6 +76,7 @@ pub fn read_v5_bundle<R: Read>(
             actions,
             flags,
             value_balance,
+            Default::default(), // FIXME: pass burns here for ZSA
             anchor,
             authorization,
         )))
@@ -133,21 +135,33 @@ pub fn read_cmx<R: Read>(mut reader: R) -> io::Result<ExtractedNoteCommitment> {
     })
 }
 
-pub fn read_note_ciphertext<R: Read>(mut reader: R) -> io::Result<TransmittedNoteCiphertext> {
-    let mut tnc = TransmittedNoteCiphertext {
+pub fn read_note_ciphertext<R: Read>(
+    mut reader: R,
+) -> io::Result<TransmittedNoteCiphertext<OrchardDomainVanilla>> {
+    /*
+            let mut epk_bytes = [0u8; 32]
+            // FIXME: use another ENC_CIPHERTEXT_SIZE for ZSA
+            let enc_ciphertext = [0u8;  ENC_CIPHERTEXT_SIZE];
+            let out_ciphertext = [0u8; 80];
+
+                enc_ciphertext: [0u8;  ENC_CIPHERTEXT_SIZE],
+    */
+    let mut tnc = TransmittedNoteCiphertext::<OrchardDomainVanilla> {
         epk_bytes: [0u8; 32],
-        enc_ciphertext: [0u8; 580],
+        enc_ciphertext: NoteCiphertextBytes([0u8; ENC_CIPHERTEXT_SIZE]),
         out_ciphertext: [0u8; 80],
     };
 
     reader.read_exact(&mut tnc.epk_bytes)?;
-    reader.read_exact(&mut tnc.enc_ciphertext)?;
+    reader.read_exact(&mut tnc.enc_ciphertext.0)?;
     reader.read_exact(&mut tnc.out_ciphertext)?;
 
     Ok(tnc)
 }
 
-pub fn read_action_without_auth<R: Read>(mut reader: R) -> io::Result<Action<()>> {
+pub fn read_action_without_auth<R: Read>(
+    mut reader: R,
+) -> io::Result<Action<(), OrchardDomainVanilla>> {
     let cv_net = read_value_commitment(&mut reader)?;
     let nf_old = read_nullifier(&mut reader)?;
     let rk = read_verification_key(&mut reader)?;
@@ -194,7 +208,7 @@ pub fn read_signature<R: Read, T: SigType>(mut reader: R) -> io::Result<Signatur
 
 /// Writes an [`orchard::Bundle`] in the v5 transaction format.
 pub fn write_v5_bundle<W: Write>(
-    bundle: Option<&orchard::Bundle<Authorized, Amount>>,
+    bundle: Option<&orchard::Bundle<Authorized, Amount, OrchardDomainVanilla>>,
     mut writer: W,
 ) -> io::Result<()> {
     if let Some(bundle) = &bundle {
@@ -246,16 +260,16 @@ pub fn write_cmx<W: Write>(mut writer: W, cmx: &ExtractedNoteCommitment) -> io::
 
 pub fn write_note_ciphertext<W: Write>(
     mut writer: W,
-    nc: &TransmittedNoteCiphertext,
+    nc: &TransmittedNoteCiphertext<OrchardDomainVanilla>,
 ) -> io::Result<()> {
     writer.write_all(&nc.epk_bytes)?;
-    writer.write_all(&nc.enc_ciphertext)?;
+    writer.write_all(nc.enc_ciphertext.as_ref())?;
     writer.write_all(&nc.out_ciphertext)
 }
 
 pub fn write_action_without_auth<W: Write>(
     mut writer: W,
-    act: &Action<<Authorized as Authorization>::SpendAuth>,
+    act: &Action<<Authorized as Authorization>::SpendAuth, OrchardDomainVanilla>,
 ) -> io::Result<()> {
     write_value_commitment(&mut writer, act.cv_net())?;
     write_nullifier(&mut writer, act.nullifier())?;

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -283,9 +283,12 @@ pub fn write_action_without_auth<W: Write>(
 pub mod testing {
     use proptest::prelude::*;
 
-    use orchard::bundle::{
-        testing::{self as t_orch},
-        Authorized, Bundle,
+    use orchard::{
+        bundle::{
+            testing::{self as t_orch},
+            Authorized, Bundle,
+        },
+        note_encryption_vanilla::OrchardDomainVanilla,
     };
 
     use crate::transaction::{
@@ -296,8 +299,8 @@ pub mod testing {
     prop_compose! {
         pub fn arb_bundle(n_actions: usize)(
             orchard_value_balance in arb_amount(),
-            bundle in t_orch::arb_bundle(n_actions)
-        ) -> Bundle<Authorized, Amount> {
+            bundle in t_orch::BundleArb::arb_bundle(n_actions)
+        ) -> Bundle<Authorized, Amount, OrchardDomainVanilla> {
             // overwrite the value balance, as we can't guarantee that the
             // value doesn't exceed the MAX_MONEY bounds.
             bundle.try_map_value_balance::<_, (), _>(|_| Ok(orchard_value_balance)).unwrap()
@@ -306,7 +309,7 @@ pub mod testing {
 
     pub fn arb_bundle_for_version(
         v: TxVersion,
-    ) -> impl Strategy<Value = Option<Bundle<Authorized, Amount>>> {
+    ) -> impl Strategy<Value = Option<Bundle<Authorized, Amount, OrchardDomainVanilla>>> {
         if v.has_orchard() {
             Strategy::boxed((1usize..100).prop_flat_map(|n| prop::option::of(arb_bundle(n))))
         } else {

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -352,7 +352,7 @@ impl<A: Authorization> TransactionData<A> {
         transparent_bundle: Option<transparent::Bundle<A::TransparentAuth>>,
         sprout_bundle: Option<sprout::Bundle>,
         sapling_bundle: Option<sapling::Bundle<A::SaplingAuth>>,
-        orchard_bundle: Option<orchard::Bundle<A::OrchardAuth, Amount>>,
+        orchard_bundle: Option<orchard::Bundle<A::OrchardAuth, Amount, OrchardDomainVanilla>>,
         tze_bundle: Option<tze::Bundle<A::TzeAuth>>,
     ) -> Self {
         TransactionData {

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use blake2b_simd::{Hash as Blake2bHash, Params, State};
 use byteorder::{LittleEndian, WriteBytesExt};
 use ff::PrimeField;
-use orchard::bundle::{self as orchard};
+use orchard::{bundle, note_encryption_vanilla::OrchardDomainVanilla};
 
 use crate::consensus::{BlockHeight, BranchId};
 
@@ -328,7 +328,7 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
 
     fn digest_orchard(
         &self,
-        orchard_bundle: Option<&orchard::Bundle<A::OrchardAuth, Amount>>,
+        orchard_bundle: Option<&bundle::Bundle<A::OrchardAuth, Amount, OrchardDomainVanilla>>,
     ) -> Self::OrchardDigest {
         orchard_bundle.map(|b| b.commitment().0)
     }
@@ -383,7 +383,7 @@ pub(crate) fn to_hash(
     .unwrap();
     h.write_all(
         orchard_digest
-            .unwrap_or_else(orchard::commitments::hash_bundle_txid_empty)
+            .unwrap_or_else(bundle::commitments::hash_bundle_txid_empty)
             .as_bytes(),
     )
     .unwrap();
@@ -483,9 +483,9 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
 
     fn digest_orchard(
         &self,
-        orchard_bundle: Option<&orchard::Bundle<orchard::Authorized, Amount>>,
+        orchard_bundle: Option<&bundle::Bundle<bundle::Authorized, Amount, OrchardDomainVanilla>>,
     ) -> Self::OrchardDigest {
-        orchard_bundle.map_or_else(orchard::commitments::hash_bundle_auth_empty, |b| {
+        orchard_bundle.map_or_else(bundle::commitments::hash_bundle_auth_empty, |b| {
             b.authorizing_commitment().0
         })
     }


### PR DESCRIPTION
This pull request aims to update `librustzcash` to utilize the modified, backward-compatible `orchard` crate. The previous version of the `orchard` crate used in `librustzcash` exclusively supported the Vanilla variant of the Orchard protocol. However, recent modifications have introduced generics to `orchard` fork, enabling it to support both Vanilla and ZSA variants. 

Modifications include:

- Updated the `zcash_primitives` and `zcash_client_backend` crates within `librustzcash` to use the modified version of the `orchard` crate.
- Modified unit tests within `librustzcash` to use the updated `orchard` crate.

Further modifications are required to fully leverage the capabilities of the Orchard ZSA variant.
