### PR TITLE
Update librustzcash to align with orchard crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
 [[package]]
 name = "halo2_gadgets"
 version = "0.3.0"
-source = "git+https://github.com/QED-it/halo2?branch=orchardzsa-backward-compatability#4cc147385e7cf106b9fab6d6951d66a343899e38"
+source = "git+https://github.com/QED-it/halo2?rev=7f5c0babd61f8ca46c9165a1adfac298d3fd3a11#7f5c0babd61f8ca46c9165a1adfac298d3fd3a11"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -794,7 +794,7 @@ checksum = "47716fe1ae67969c5e0b2ef826f32db8c3be72be325e1aa3c1951d06b5575ec5"
 [[package]]
 name = "halo2_proofs"
 version = "0.3.0"
-source = "git+https://github.com/QED-it/halo2?branch=orchardzsa-backward-compatability#4cc147385e7cf106b9fab6d6951d66a343899e38"
+source = "git+https://github.com/QED-it/halo2?rev=7f5c0babd61f8ca46c9165a1adfac298d3fd3a11#7f5c0babd61f8ca46c9165a1adfac298d3fd3a11"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -1229,7 +1229,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "orchard"
 version = "0.8.0"
-source = "git+https://github.com/QED-it/orchard?branch=orchardzsa-backward-compatability-0.8.0-ak#984276d113f6ef2563a26feb8c634ffbda0d31c6"
+source = "git+https://github.com/QED-it/orchard?branch=orchardzsa-backward-compatability-0.8.0#c4baaa7c09f76c3a396f41c9b40b03039c6b18a8"
 dependencies = [
  "aes",
  "bitvec",
@@ -1253,7 +1253,7 @@ dependencies = [
  "serde",
  "subtle",
  "tracing",
- "zcash_note_encryption",
+ "zcash_note_encryption 0.4.0 (git+https://github.com/QED-it/zcash_note_encryption?branch=zsa1)",
  "zcash_spec",
  "zip32",
 ]
@@ -1776,7 +1776,7 @@ dependencies = [
  "redjubjub",
  "subtle",
  "tracing",
- "zcash_note_encryption",
+ "zcash_note_encryption 0.4.0 (git+https://github.com/QED-it/zcash_note_encryption?branch=fix-sapling-constants)",
  "zcash_spec",
  "zip32",
 ]
@@ -2497,6 +2497,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_note_encryption"
+version = "0.4.0"
+source = "git+https://github.com/QED-it/zcash_note_encryption?branch=zsa1#b8bd2a186fc04ec4f55b2db44df7374f03ab5725"
+dependencies = [
+ "chacha20",
+ "chacha20poly1305",
+ "cipher",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "zcash_primitives"
 version = "0.15.0"
 dependencies = [
@@ -2533,7 +2545,7 @@ dependencies = [
  "tracing",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption",
+ "zcash_note_encryption 0.4.0 (git+https://github.com/QED-it/zcash_note_encryption?branch=fix-sapling-constants)",
  "zcash_protocol",
  "zcash_spec",
  "zip32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,7 +1229,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "orchard"
 version = "0.8.0"
-source = "git+https://github.com/QED-it/orchard?branch=orchardzsa-backward-compatability-0.8.0#c4baaa7c09f76c3a396f41c9b40b03039c6b18a8"
+source = "git+https://github.com/QED-it/orchard?branch=zsa1#39b479ea81045e5c5ac719821fe2feb2bfce5f36"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ sapling = { package = "sapling-crypto", version = "0.1.3" }
 
 # - Orchard
 nonempty = "0.7"
-orchard = { version = "0.8.0", default-features = false, git = "https://github.com/QED-it/orchard", branch = "orchardzsa-backward-compatability-0.8.0-ak" }
+orchard = { version = "0.8.0", default-features = false, git = "https://github.com/QED-it/orchard", branch = "orchardzsa-backward-compatability-0.8.0" }
 pasta_curves = "0.5"
 
 # - Transparent

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ sapling = { package = "sapling-crypto", version = "0.1.3" }
 
 # - Orchard
 nonempty = "0.7"
-orchard = { version = "0.8.0", default-features = false, git = "https://github.com/QED-it/orchard", branch = "orchardzsa-backward-compatability-0.8.0" }
+orchard = { version = "0.8.0", default-features = false, git = "https://github.com/QED-it/orchard", branch = "zsa1" }
 pasta_curves = "0.5"
 
 # - Transparent

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -53,8 +53,8 @@ use crate::{
 #[cfg(zcash_unstable = "nu6")] /* TODO nu7 */
 use crate::transaction::builder::Error::{IssuanceBuilder, IssuanceBundle};
 use orchard::note::AssetBase;
-use orchard::orchard_flavors::OrchardVanilla;
-#[cfg(zcash_unstable = "nu6")] /* TODO nu7 */ use orchard::orchard_flavors::OrchardZSA;
+use orchard::orchard_flavor::OrchardVanilla;
+#[cfg(zcash_unstable = "nu6")] /* TODO nu7 */ use orchard::orchard_flavor::OrchardZSA;
 #[cfg(zcash_unstable = "nu6")] /* TODO nu7 */
 use orchard::{
     issuance::{IssueBundle, IssueInfo},

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -15,8 +15,7 @@ mod tests;
 use blake2b_simd::Hash as Blake2bHash;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use memuse::DynamicUsage;
-use orchard::builder::Unproven;
-use orchard::orchard_flavors::OrchardVanilla;
+use orchard::{builder::Unproven, orchard_flavor::OrchardVanilla, value::NoteValue};
 use std::convert::TryFrom;
 use std::fmt;
 use std::fmt::Debug;
@@ -31,7 +30,7 @@ use crate::{
 
 #[cfg(zcash_unstable = "nu6")] /* TODO nu7 */ use crate::transaction::components::issuance;
 #[cfg(zcash_unstable = "nu6")] /* TODO nu7 */
-use orchard::{issuance::IssueBundle, orchard_flavors::OrchardZSA};
+use orchard::{issuance::IssueBundle, orchard_flavor::OrchardZSA};
 
 use self::{
     components::{
@@ -862,6 +861,12 @@ impl Transaction {
         reader.read_exact(&mut tmp)?;
         Amount::from_i64_le_bytes(tmp)
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "valueBalance out of range"))
+    }
+
+    fn read_note_value<R: Read>(mut reader: R) -> io::Result<NoteValue> {
+        let mut tmp = [0; 8];
+        reader.read_exact(&mut tmp)?;
+        Ok(NoteValue::from_bytes(tmp))
     }
 
     fn read_v5<R: Read>(mut reader: R, version: TxVersion) -> io::Result<Self> {

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -6,11 +6,11 @@ use blake2b_simd::{Hash as Blake2bHash, Params, State};
 use byteorder::{LittleEndian, WriteBytesExt};
 use ff::PrimeField;
 use orchard::bundle;
-use orchard::orchard_flavors::OrchardVanilla;
+use orchard::orchard_flavor::OrchardVanilla;
 #[cfg(zcash_unstable = "nu6")] /* TODO nu7 */
 use orchard::{
     issuance::{IssueBundle, Signed},
-    orchard_flavors::OrchardZSA,
+    orchard_flavor::OrchardZSA,
 };
 
 use crate::{


### PR DESCRIPTION
This PR updates `librustzcash` to accommodate the recent refactoring changes in the `orchard` crate. The specific changes include:

- Renamed all references from `orchard_flavors` to `orchard_flavor` to match the new module name.
- Updated the `OrchardDomain` trait references to `OrchardDomainCommon` to reflect the trait renaming.
- Adjusted the `Bundle` structure to use the fixed `NoteValue` type for the `burn` field, replacing the previous generic argument.
- Refactored associated code to align with the new structure and naming conventions in the `orchard` crate.
- Switched from the `orchardzsa-backward-compatibility-0.8.0-ak` to `orchardzsa-backward-compatibility-0.8.0` branch in `Cargo.toml` to use the latest version of the `orchard` crate.
