### PR TITLE
Update zcash_primitives to sync with latest sapling-crypto changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,7 +1229,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "orchard"
 version = "0.8.0"
-source = "git+https://github.com/QED-it/orchard?branch=zsa1#6e6112c80eb751a93c0fd1d881e9ca69887e1154"
+source = "git+https://github.com/QED-it/orchard?branch=zsa1#07b3697b271f04c736a5f7e130d186e68a85fd8c"
 dependencies = [
  "aes",
  "bitvec",
@@ -1752,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "sapling-crypto"
 version = "0.1.3"
-source = "git+https://github.com/QED-it/sapling-crypto?branch=zsa1#e19f4d916360842becf2842bfd9b27228e66fa81"
+source = "git+https://github.com/QED-it/sapling-crypto?branch=zsa1#99ad0a5f0bdef332bdc91d577086abd3aca59553"
 dependencies = [
  "aes",
  "bellman",
@@ -2487,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.4.0"
-source = "git+https://github.com/QED-it/zcash_note_encryption?branch=zsa1#58384553aab76b2ee6d6eb328cf2187fa824ec9a"
+source = "git+https://github.com/QED-it/zcash_note_encryption?branch=zsa1#76745f00551d4442dee11ad64a8400b75132d18f"
 dependencies = [
  "chacha20",
  "chacha20poly1305",

--- a/zcash_primitives/src/transaction/components/sapling.rs
+++ b/zcash_primitives/src/transaction/components/sapling.rs
@@ -1,12 +1,12 @@
 use ff::PrimeField;
 use redjubjub::SpendAuth;
-use sapling::note_encryption::Zip212Enforcement;
+use sapling::note_encryption::{Zip212Enforcement, ENC_CIPHERTEXT_SIZE};
 use zcash_protocol::consensus::{BlockHeight, NetworkUpgrade, Parameters, ZIP212_GRACE_PERIOD};
 
 use std::io::{self, Read, Write};
 
 use zcash_encoding::{Array, CompactSize, Vector};
-use zcash_note_encryption::{EphemeralKeyBytes, ENC_CIPHERTEXT_SIZE, OUT_CIPHERTEXT_SIZE};
+use zcash_note_encryption::{EphemeralKeyBytes, OUT_CIPHERTEXT_SIZE};
 
 use crate::{
     sapling::{
@@ -270,7 +270,7 @@ pub(crate) fn write_output_v4<W: Write>(
     writer.write_all(&output.cv().to_bytes())?;
     writer.write_all(output.cmu().to_bytes().as_ref())?;
     writer.write_all(output.ephemeral_key().as_ref())?;
-    writer.write_all(output.enc_ciphertext())?;
+    writer.write_all(output.enc_ciphertext().as_ref())?;
     writer.write_all(output.out_ciphertext())?;
     writer.write_all(output.zkproof())
 }
@@ -282,7 +282,7 @@ fn write_output_v5_without_proof<W: Write>(
     writer.write_all(&output.cv().to_bytes())?;
     writer.write_all(output.cmu().to_bytes().as_ref())?;
     writer.write_all(output.ephemeral_key().as_ref())?;
-    writer.write_all(output.enc_ciphertext())?;
+    writer.write_all(output.enc_ciphertext().as_ref())?;
     writer.write_all(output.out_ciphertext())
 }
 

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -189,12 +189,15 @@ pub(crate) fn hash_sapling_outputs<A>(shielded_outputs: &[OutputDescription<A>])
         for s_out in shielded_outputs {
             ch.write_all(s_out.cmu().to_bytes().as_ref()).unwrap();
             ch.write_all(s_out.ephemeral_key().as_ref()).unwrap();
-            ch.write_all(&s_out.enc_ciphertext()[..52]).unwrap();
+            ch.write_all(&s_out.enc_ciphertext().as_ref()[..52])
+                .unwrap();
 
-            mh.write_all(&s_out.enc_ciphertext()[52..564]).unwrap();
+            mh.write_all(&s_out.enc_ciphertext().as_ref()[52..564])
+                .unwrap();
 
             nh.write_all(&s_out.cv().to_bytes()).unwrap();
-            nh.write_all(&s_out.enc_ciphertext()[564..]).unwrap();
+            nh.write_all(&s_out.enc_ciphertext().as_ref()[564..])
+                .unwrap();
             nh.write_all(&s_out.out_ciphertext()[..]).unwrap();
         }
 


### PR DESCRIPTION
This PR updates the `zcash_primitives` crate to align with the recent changes in the `sapling-crypto` crate, which was updated to sync with the latest changes in `zcash_note_encryption`.

### Changes:
- Updated the usage of `enc_ciphertext` to call `.as_ref()` to match the new return type.
- Adjusted the import of the `ENC_CIPHERTEXT_SIZE` constant to use the definition from `sapling-crypto` instead of `zcash_note_encryption`, as the constant has been moved to `sapling-crypto`.