### PR TITLE
Provide Zebra compatibility: re-enable and fix zcash_client_backend, update prost dependency version (2)

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -31,6 +31,7 @@ runs:
         transparent-inputs
         sapling
         unstable
+        unstable-spanning-tree
         ${{ inputs.extra-features }}
         ${{ steps.test.outputs.feature }}
         '" >> $GITHUB_OUTPUT

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -31,7 +31,6 @@ runs:
         transparent-inputs
         sapling
         unstable
-        unstable-spanning-tree
         ${{ inputs.extra-features }}
         ${{ steps.test.outputs.feature }}
         '" >> $GITHUB_OUTPUT

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ maybe-rayon = { version = "0.1.0", default-features = false }
 rayon = "1.5"
 
 # Protobuf and gRPC
-prost = "=0.12.6"
+prost = "0.12.6"
 tonic = { version = "0.10", default-features = false }
 tonic-build = { version = "0.10", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "components/zcash_encoding",
     "components/zcash_protocol",
     "components/zip321",
+    # zcash_client_backend and zcash_client_sqlite are not compatible with OrchardZSA
 #    "zcash_client_backend",
 #    "zcash_client_sqlite",
     "zcash_extensions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ maybe-rayon = { version = "0.1.0", default-features = false }
 rayon = "1.5"
 
 # Protobuf and gRPC
-prost = "=0.12.3"
+prost = "=0.12.6"
 tonic = { version = "0.10", default-features = false }
 tonic-build = { version = "0.10", default-features = false }
 


### PR DESCRIPTION
Updates the repository to ensure compatibility with the `zebra` project.

## Changes:

1. Uncommented the `zcash_client_backend` crate in the root `Cargo.toml`. Initially it was commented out under the assumption that it wasn't utilized by Zebra. However, it has been identified that Zebra relies on this crate.

2. Synchronized `zcash_client_backend` crate with `zcash_note_encryption` updates.

3. Updated the `prost` dependency version in the root `Cargo.toml` (the pinned version 0.12.3 caused compatibility issues with Zebra’s dependencies, preventing compilation).