### PR TITLE
Add Regtest network

### DIFF
--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -396,13 +396,43 @@ impl Parameters for TestNetwork {
     }
 }
 
-/// The enumeration of known Zcash networks.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+/// Marker struct for the regtest network.
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub struct RegtestNetwork;
+
+memuse::impl_no_dynamic_usage!(RegtestNetwork);
+
+pub const REGTEST_NETWORK: RegtestNetwork = RegtestNetwork;
+
+impl Parameters for RegtestNetwork {
+    fn network_type(&self) -> NetworkType {
+        NetworkType::Regtest
+    }
+
+    fn activation_height(&self, nu: NetworkUpgrade) -> Option<BlockHeight> {
+        match nu {
+            NetworkUpgrade::Overwinter => Some(BlockHeight(1)),
+            NetworkUpgrade::Sapling => Some(BlockHeight(1)),
+            NetworkUpgrade::Blossom => Some(BlockHeight(1)),
+            NetworkUpgrade::Heartwood => Some(BlockHeight(1)),
+            NetworkUpgrade::Canopy => Some(BlockHeight(1)),
+            NetworkUpgrade::Nu5 => Some(BlockHeight(1)),
+            NetworkUpgrade::Nu6 => Some(BlockHeight(1)),
+            NetworkUpgrade::Nu7 => Some(BlockHeight(1)),
+            #[cfg(feature = "zfuture")]
+            NetworkUpgrade::ZFuture => None,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum Network {
     /// Zcash Mainnet.
     MainNetwork,
     /// Zcash Testnet.
     TestNetwork,
+    /// Zcash Regtest.
+    RegtestNetwork,
 }
 
 memuse::impl_no_dynamic_usage!(Network);
@@ -412,6 +442,7 @@ impl Parameters for Network {
         match self {
             Network::MainNetwork => NetworkType::Main,
             Network::TestNetwork => NetworkType::Test,
+            Network::RegtestNetwork => NetworkType::Regtest,
         }
     }
 
@@ -419,6 +450,7 @@ impl Parameters for Network {
         match self {
             Network::MainNetwork => MAIN_NETWORK.activation_height(nu),
             Network::TestNetwork => TEST_NETWORK.activation_height(nu),
+            Network::RegtestNetwork => REGTEST_NETWORK.activation_height(nu),
         }
     }
 }

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -421,7 +421,7 @@ impl Parameters for RegtestNetwork {
             NetworkUpgrade::Nu6 => Some(BlockHeight(1)),
             #[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
             NetworkUpgrade::Nu7 => Some(BlockHeight(1)),
-            #[cfg(feature = "zfuture")]
+            #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => None,
         }
     }

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -417,7 +417,9 @@ impl Parameters for RegtestNetwork {
             NetworkUpgrade::Heartwood => Some(BlockHeight(1)),
             NetworkUpgrade::Canopy => Some(BlockHeight(1)),
             NetworkUpgrade::Nu5 => Some(BlockHeight(1)),
+            #[cfg(zcash_unstable = "nu6")]
             NetworkUpgrade::Nu6 => Some(BlockHeight(1)),
+            #[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
             NetworkUpgrade::Nu7 => Some(BlockHeight(1)),
             #[cfg(feature = "zfuture")]
             NetworkUpgrade::ZFuture => None,

--- a/components/zcash_protocol/src/consensus.rs
+++ b/components/zcash_protocol/src/consensus.rs
@@ -427,7 +427,7 @@ impl Parameters for RegtestNetwork {
     }
 }
 
-#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 pub enum Network {
     /// Zcash Mainnet.
     MainNetwork,

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -1215,6 +1215,7 @@ pub mod testing {
     #[cfg(zcash_unstable = "zfuture")]
     use super::components::tze::testing::{self as tze};
 
+    #[cfg(not(zcash_unstable = "zfuture"))]
     use crate::transaction::components::issuance;
 
     pub fn arb_txid() -> impl Strategy<Value = TxId> {


### PR DESCRIPTION
### **User description**
Add Regtest network


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a new `RegtestNetwork` struct to support the regtest network.
- Implemented the `Parameters` trait for `RegtestNetwork`, defining its network type and activation heights.
- Added `RegtestNetwork` to the `Network` enum and updated the `Parameters` implementation to handle it.
- This enhancement allows the system to recognize and operate with the regtest network configuration.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>consensus.rs</strong><dd><code>Add support for Regtest network in consensus module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/zcash_protocol/src/consensus.rs

<li>Added a new <code>RegtestNetwork</code> struct and implemented the <code>Parameters</code> trait <br>for it.<br> <li> Introduced a constant <code>REGTEST_NETWORK</code> for the regtest network.<br> <li> Updated the <code>Network</code> enum to include <code>RegtestNetwork</code>.<br> <li> Modified the <code>Parameters</code> implementation for <code>Network</code> to handle <br><code>RegtestNetwork</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/QED-it/librustzcash/pull/77/files#diff-76e7f73d07dade3e464b14a24effef907112a223f6454060cb4c443e364253d8">+36/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information