### PR TITLE
Refactor burn serialization functions in zcash_primitives

### DIFF
--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -153,6 +153,7 @@ fn read_burn_item<R: Read>(reader: &mut R) -> io::Result<(AssetBase, NoteValue)>
     Ok((read_asset(reader)?, read_note_value(reader)?))
 }
 
+/// Reads burn for OrchardZSA
 #[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
 pub fn read_burn<R: Read>(mut reader: &mut R) -> io::Result<Vec<(AssetBase, NoteValue)>> {
     Vector::read(&mut reader, read_burn_item)
@@ -282,7 +283,7 @@ fn read_note_value<R: Read>(mut reader: R) -> io::Result<NoteValue> {
     Ok(NoteValue::from_bytes(bytes))
 }
 
-// Write burn for OrchardZSA
+/// Writes burn for OrchardZSA
 #[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
 pub fn write_burn<W: Write>(writer: &mut W, burn: &[(AssetBase, NoteValue)]) -> io::Result<()> {
     Vector::write(writer, burn, |w, (asset, amount)| {

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -284,7 +284,7 @@ fn read_note_value<R: Read>(mut reader: R) -> io::Result<NoteValue> {
 
 // Write burn for OrchardZSA
 #[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
-fn write_burn<W: Write>(writer: &mut W, burn: &[(AssetBase, NoteValue)]) -> io::Result<()> {
+pub fn write_burn<W: Write>(writer: &mut W, burn: &[(AssetBase, NoteValue)]) -> io::Result<()> {
     Vector::write(writer, burn, |w, (asset, amount)| {
         w.write_all(&asset.to_bytes())?;
         w.write_all(&amount.to_bytes())?;

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -132,7 +132,7 @@ pub fn read_orchard_zsa_bundle<R: Read>(
 
     let value_balance = Transaction::read_amount(&mut reader)?;
 
-    let burn = Vector::read(&mut reader, |r| read_burn(r))?;
+    let burn = read_burn(&mut reader)?;
 
     let binding_signature = read_signature::<_, redpallas::Binding>(&mut reader)?;
 
@@ -149,8 +149,13 @@ pub fn read_orchard_zsa_bundle<R: Read>(
 }
 
 #[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
-fn read_burn<R: Read>(reader: &mut R) -> io::Result<(AssetBase, NoteValue)> {
+fn read_burn_item<R: Read>(reader: &mut R) -> io::Result<(AssetBase, NoteValue)> {
     Ok((read_asset(reader)?, read_note_value(reader)?))
+}
+
+#[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
+pub fn read_burn<R: Read>(mut reader: &mut R) -> io::Result<Vec<(AssetBase, NoteValue)>> {
+    Vector::read(&mut reader, read_burn_item)
 }
 
 pub fn read_value_commitment<R: Read>(mut reader: R) -> io::Result<ValueCommitment> {

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -11,12 +11,14 @@ use nonempty::NonEmpty;
 use orchard::{
     bundle::{Authorization, Authorized, Flags},
     domain::OrchardDomainCommon,
-    note::{AssetBase, ExtractedNoteCommitment, Nullifier, TransmittedNoteCiphertext},
-    orchard_flavor::{OrchardVanilla, OrchardZSA},
+    note::{ExtractedNoteCommitment, Nullifier, TransmittedNoteCiphertext},
+    orchard_flavor::OrchardVanilla,
     primitives::redpallas::{self, SigType, Signature, SpendAuth, VerificationKey},
-    value::{NoteValue, ValueCommitment},
+    value::ValueCommitment,
     Action, Anchor, Bundle,
 };
+#[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
+use orchard::{note::AssetBase, orchard_flavor::OrchardZSA, value::NoteValue};
 use zcash_encoding::{Array, CompactSize, Vector};
 use zcash_note_encryption::note_bytes::NoteBytes;
 


### PR DESCRIPTION
This PR refactors the burn serialization functions in the `zcash_primitives`. Specifically, the `WriteBurn` trait has been removed and replaced by a free function, `write_burn`, which is now public. Additionally, the original `read_burn` function is renamed to `read_burn_item`, and a new public function, `read_burn`, is introduced to read the entire burn field (a vector of burn items), enabling `zebra` to utilize these serialization functions.