### PR TITLE
Update Cargo.toml/Cargo.lock to use the latest version of zsa1 branch of orchard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,7 +1530,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "orchard"
 version = "0.8.0"
-source = "git+https://github.com/QED-it/orchard?rev=b62f72a8ebebe0faf81764260ea961011066aba5#b62f72a8ebebe0faf81764260ea961011066aba5"
+source = "git+https://github.com/QED-it/orchard?rev=e88e2614bdc56119d5e0c9cb5f30fb4cc5c92dc7#e88e2614bdc56119d5e0c9cb5f30fb4cc5c92dc7"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,4 +127,4 @@ codegen-units = 1
 [patch.crates-io]
 zcash_note_encryption = { version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1" }
 sapling = { package = "sapling-crypto", version = "0.1.3", git = "https://github.com/QED-it/sapling-crypto", branch = "zsa1" }
-orchard = { version = "0.8.0", git = "https://github.com/QED-it/orchard", rev = "b62f72a8ebebe0faf81764260ea961011066aba5" }
+orchard = { version = "0.8.0", git = "https://github.com/QED-it/orchard", rev = "e88e2614bdc56119d5e0c9cb5f30fb4cc5c92dc7" }


### PR DESCRIPTION
Update Cargo.toml/Cargo.lock to use the latest version of zsa1 branch of orchard