### PR TITLE
Fix issue bundle hash calculation

### DIFF
--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -56,6 +56,7 @@ use crate::{
 use orchard::bundle::Authorized;
 #[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
 use orchard::{
+    bundle::Authorization,
     issuance,
     issuance::{IssueBundle, IssueInfo},
     keys::{IssuanceAuthorizingKey, IssuanceValidatingKey},
@@ -64,8 +65,6 @@ use orchard::{
 };
 #[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
 use rand_core::OsRng;
-#[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
-use std::io;
 
 /// Since Blossom activation, the default transaction expiry delta should be 40 blocks.
 /// <https://zips.z.cash/zip-0203#changes-for-blossom>
@@ -894,6 +893,11 @@ impl<'a, P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<
         #[cfg(zcash_unstable = "zfuture")]
         let (tze_bundle, tze_signers) = self.tze_builder.build();
 
+        #[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
+        let issue_bundle_awaiting_sighash = self
+            .issuance_builder
+            .map(|b| b.update_rho(first_nullifier(&unproven_orchard_bundle)));
+
         let unauthed_tx: TransactionData<Unauthorized> = TransactionData {
             version,
             consensus_branch_id: BranchId::for_height(&self.params, self.target_height),
@@ -904,7 +908,7 @@ impl<'a, P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<
             sapling_bundle,
             orchard_bundle: unproven_orchard_bundle,
             #[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
-            issue_bundle: self.issuance_builder,
+            issue_bundle: issue_bundle_awaiting_sighash,
             #[cfg(zcash_unstable = "zfuture")]
             tze_bundle,
         };
@@ -975,7 +979,6 @@ impl<'a, P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<
         #[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
         let issue_bundle = unauthed_tx
             .issue_bundle
-            .map(|b| b.update_rho(first_nullifier(&orchard_bundle)))
             .map(|b| b.prepare(*shielded_sig_commitment.as_ref()))
             .map(|b| b.sign(self.issuance_isk.as_ref().unwrap()))
             .map(|b| b.unwrap());
@@ -1024,7 +1027,7 @@ where
 /// This function returns the first nullifier from the first transfer action in the Orchard bundle.
 /// It can only be called on ZSA bundle, will panic in case of invalid input e.g. Vanilla or empty bundle.
 #[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
-fn first_nullifier(orchard_bundle: &Option<OrchardBundle<Authorized>>) -> &Nullifier {
+fn first_nullifier<A: Authorization>(orchard_bundle: &Option<OrchardBundle<A>>) -> &Nullifier {
     match orchard_bundle {
         Some(OrchardBundle::OrchardZSA(b)) => b.actions().first().nullifier(),
         _ => panic!("first_nullifier called on non-ZSA bundle, this should never happen"),

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -334,7 +334,7 @@ impl Authorization for Unauthorized {
     type OrchardAuth = orchard::builder::InProgress<Unproven, orchard::builder::Unauthorized>;
 
     #[cfg(zcash_unstable = "nu6" /* TODO nu7 */ )]
-    type IssueAuth = orchard::issuance::AwaitingNullifier;
+    type IssueAuth = orchard::issuance::AwaitingSighash;
 
     #[cfg(zcash_unstable = "zfuture")]
     type TzeAuth = tze::builder::Unauthorized;


### PR DESCRIPTION
Method 'update_rho' changes the hash of an issue bundle. Because of that its call should happen before sighash calculation.