### PR TITLE
Bump Orchard rev to commit that supports range of proptest versions (from 1.0.0 to <1.7.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,7 +2848,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.11.0"
-source = "git+https://github.com/QED-it/orchard?rev=9f44f55eca726114a4b89793b2a59fe386e638ed#9f44f55eca726114a4b89793b2a59fe386e638ed"
+source = "git+https://github.com/QED-it/orchard?rev=01758ea45adf480746e783934fe9ef5a058fb703#01758ea45adf480746e783934fe9ef5a058fb703"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,4 +221,4 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 [patch.crates-io]
 zcash_note_encryption = { version = "0.4.1", git = "https://github.com/zcash/zcash_note_encryption", branch = "main" }
 sapling = { package = "sapling-crypto", version = "0.5", git = "https://github.com/QED-it/sapling-crypto", branch = "zsa1" }
-orchard = { version = "0.11.0", git = "https://github.com/QED-it/orchard", rev = "9f44f55eca726114a4b89793b2a59fe386e638ed" }
+orchard = { version = "0.11.0", git = "https://github.com/QED-it/orchard", rev = "01758ea45adf480746e783934fe9ef5a058fb703" }


### PR DESCRIPTION
Updates the `orchard` Git revision in `Cargo.toml` so `orchard` can build with any `proptest` version from 1.0.0 up to — but not including — 1.7.0.
No code changes, just a dependency bump to align with the new version range.

See QED-it/orchard#177 for the corresponding Orchard PR.