### PR TITLE
Update proptest version and orchard revision for consistency with upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,7 +2848,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.11.0"
-source = "git+https://github.com/QED-it/orchard?rev=01758ea45adf480746e783934fe9ef5a058fb703#01758ea45adf480746e783934fe9ef5a058fb703"
+source = "git+https://github.com/QED-it/orchard?rev=806878c75e491ec7815af86ee08d761c7ed527b5#806878c75e491ec7815af86ee08d761c7ed527b5"
 dependencies = [
  "aes",
  "bitvec",
@@ -3344,19 +3344,19 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
- "byteorder",
+ "bit-vec",
+ "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ static_assertions = "1"
 ambassador = "0.4"
 assert_matches = "1.5"
 criterion = "0.5"
-proptest = "=1.2.0"
+proptest = ">=1,<1.7" # proptest 1.7 updates to rand 0.9
 rand_chacha = "0.3"
 rand_xorshift = "0.3"
 incrementalmerkletree-testing = "0.3"
@@ -221,4 +221,4 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 [patch.crates-io]
 zcash_note_encryption = { version = "0.4.1", git = "https://github.com/zcash/zcash_note_encryption", branch = "main" }
 sapling = { package = "sapling-crypto", version = "0.5", git = "https://github.com/QED-it/sapling-crypto", branch = "zsa1" }
-orchard = { version = "0.11.0", git = "https://github.com/QED-it/orchard", rev = "01758ea45adf480746e783934fe9ef5a058fb703" }
+orchard = { version = "0.11.0", git = "https://github.com/QED-it/orchard", rev = "806878c75e491ec7815af86ee08d761c7ed527b5" }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -954,7 +954,7 @@ version = "2.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.proptest]]
-version = "1.2.0"
+version = "1.3.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.prost]]


### PR DESCRIPTION
This PR:

- Aligns `proptest` version in `Cargo.toml`, `Cargo.lock`, and `supply-chain/config.toml` with upstream `librustzcash`.
- Updates `orchard` revision hash to a `zsa1` commit that includes matching proptest changes.