### PR TITLE
Gate zsa builder on tx_version and remove stale halo2 patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7550,8 +7550,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "halo2_proofs"
-version = "0.3.1"
-source = "git+https://github.com/zcash/halo2?rev=2308caf68c48c02468b66cfc452dad54e355e32f#2308caf68c48c02468b66cfc452dad54e355e32f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,5 +234,4 @@ sapling = { package = "sapling-crypto", git = "https://github.com/QED-it/sapling
 orchard = { git = "https://github.com/QED-it/orchard", rev = "92db1ee1c3d11481bc96c90ba64a060a5c48dd67" }
 sinsemilla = { git = "https://github.com/zcash/sinsemilla", rev = "aabb707e862bc3d7b803c77d14e5a771bcee3e8c" }
 zcash_note_encryption = { git = "https://github.com/zcash/zcash_note_encryption", rev = "9f7e93d42cef839d02b9d75918117941d453f8cb" }
-halo2_proofs = { git = "https://github.com/zcash/halo2", rev = "2308caf68c48c02468b66cfc452dad54e355e32f" }
 zcash_spec = { git = "https://github.com/QED-it/zcash_spec", rev = "d5e84264d2ad0646b587a837f4e2424ca64d3a05" }

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -508,9 +508,13 @@ impl<'a, P: consensus::Parameters> Builder<'a, P, ()> {
     /// The expiry height will be set to the given height plus the default transaction
     /// expiry delta (20 blocks).
     pub fn new(params: P, target_height: BlockHeight, build_config: BuildConfig) -> Self {
+        // Determine the default transaction version for the consensus branch
+        let consensus_branch_id = BranchId::for_height(&params, target_height);
+        let tx_version = TxVersion::suggested_for_branch(consensus_branch_id);
+
         let orchard_builder = if params.is_nu_active(NetworkUpgrade::Nu5, target_height) {
             #[cfg(zcash_unstable = "nu7")]
-            if params.is_nu_active(NetworkUpgrade::Nu7, target_height) {
+            if tx_version.has_orchard_zsa() {
                 build_config.orchard_builder_config().map(|(_, anchor)| {
                     orchard::builder::Builder::new(
                         orchard::builder::BundleType::DEFAULT_ZSA,
@@ -556,10 +560,6 @@ impl<'a, P: consensus::Parameters> Builder<'a, P, ()> {
         } else {
             target_height + DEFAULT_TX_EXPIRY_DELTA
         };
-
-        // Determine the default transaction version for the consensus branch
-        let consensus_branch_id = BranchId::for_height(&params, target_height);
-        let tx_version = TxVersion::suggested_for_branch(consensus_branch_id);
 
         Builder {
             params,


### PR DESCRIPTION
- Use `tx_version.has_orchard_zsa()` instead of `is_nu_active(Nu7)` to select the Orchard ZSA builder, consistent with all other ZSA guard checks.
- Remove unused halo2_proofs patch (workspace uses v0.3.2, patch targeted v0.3.1).