### PR TITLE
Restore public issuance::read_note and update orchard revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,7 +2976,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.12.0"
-source = "git+https://github.com/QED-it/orchard?rev=92db1ee1c3d11481bc96c90ba64a060a5c48dd67#92db1ee1c3d11481bc96c90ba64a060a5c48dd67"
+source = "git+https://github.com/QED-it/orchard?rev=77d3274cb1f4620e9a1b86477c490fa123dff6bd#77d3274cb1f4620e9a1b86477c490fa123dff6bd"
 dependencies = [
  "aes",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,7 +231,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 
 [patch.crates-io]
 sapling = { package = "sapling-crypto", git = "https://github.com/QED-it/sapling-crypto", rev = "59535fb5d34b5c5cf1b20ef18269f5c65228378c" }
-orchard = { git = "https://github.com/QED-it/orchard", rev = "92db1ee1c3d11481bc96c90ba64a060a5c48dd67" }
+orchard = { git = "https://github.com/QED-it/orchard", rev = "77d3274cb1f4620e9a1b86477c490fa123dff6bd" }
 sinsemilla = { git = "https://github.com/zcash/sinsemilla", rev = "aabb707e862bc3d7b803c77d14e5a771bcee3e8c" }
 zcash_note_encryption = { git = "https://github.com/zcash/zcash_note_encryption", rev = "9f7e93d42cef839d02b9d75918117941d453f8cb" }
 zcash_spec = { git = "https://github.com/QED-it/zcash_spec", rev = "d5e84264d2ad0646b587a837f4e2424ca64d3a05" }

--- a/zcash_primitives/src/transaction/components/issuance.rs
+++ b/zcash_primitives/src/transaction/components/issuance.rs
@@ -92,7 +92,7 @@ fn read_action<R: Read>(
 }
 
 #[cfg(zcash_unstable = "nu7")]
-pub(crate) fn read_note<R: Read>(mut reader: R, asset: AssetBase) -> io::Result<Note> {
+pub fn read_note<R: Read>(mut reader: R, asset: AssetBase) -> io::Result<Note> {
     let recipient = read_recipient(&mut reader)?;
     let mut value_bytes = [0u8; 8];
     reader.read_exact(&mut value_bytes)?;


### PR DESCRIPTION
This restores `zcash_primitives::transaction::components::issuance::read_note` from `pub(crate)` back to `pub`.

It was changed from `pub` to `pub(crate)` recently in PR #224, which broke downstream builds in our Zebra fork. Zebra uses this function in `zebra-chain/src/orchard_zsa/asset_state.rs` to deserialize the reference note in `AssetState::from_bytes`, so it needs to remain public.

See the Zebra code here:

https://github.com/QED-it/zebra/blob/2634fd662a4eaca6df901c82b1bc05d2982636d7/zebra-chain/src/orchard_zsa/asset_state.rs#L60

This PR also updates the orchard dependency revision in `Cargo.toml` to the latest commit on our `zsa1` branch. That update is unrelated, but we decided to include it here as well.