### PR TITLE
Replace yanked core2 crate with core3 (pinned =0.1.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,8 +824,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 [[package]]
 name = "core2"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
+source = "git+https://github.com/bbqsrc/core2?rev=7bf2611bd9a52b438300c640e142ad5c1298b05b#7bf2611bd9a52b438300c640e142ad5c1298b05b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,6 +230,8 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [patch.crates-io]
+# core2 0.3.x was yanked from crates.io (Apr 2026); patch to the archived git source
+core2 = { git = "https://github.com/bbqsrc/core2", rev = "7bf2611bd9a52b438300c640e142ad5c1298b05b" }
 sapling = { package = "sapling-crypto", git = "https://github.com/QED-it/sapling-crypto", rev = "59535fb5d34b5c5cf1b20ef18269f5c65228378c" }
 orchard = { git = "https://github.com/QED-it/orchard", rev = "77d3274cb1f4620e9a1b86477c490fa123dff6bd" }
 sinsemilla = { git = "https://github.com/zcash/sinsemilla", rev = "aabb707e862bc3d7b803c77d14e5a771bcee3e8c" }


### PR DESCRIPTION
All core2 0.3.x versions were yanked from crates.io in April 2026.

Redirect resolution to the original repo at the 0.3.3 commit via [patch.crates-io], which covers both direct and transitive deps (orchard, sapling-crypto).